### PR TITLE
fix: 선착순 이벤트 Test API에서 오늘 날짜 기준으로 이벤트 삽입하도록 변경

### DIFF
--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/RushEventService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/RushEventService.java
@@ -163,7 +163,8 @@ public class RushEventService {
         rushOptionRepository.deleteAllInBatch();
         rushEventRepository.deleteAllInBatch();
 
-        LocalDateTime startDateTime = LocalDateTime.of(2024, 8, 11, 22, 0);
+        // 현재 날짜와 시간을 기준으로 이벤트 시간 설정
+        LocalDateTime startDateTime = LocalDateTime.now().withHour(22).withMinute(0).withSecond(0).withNano(0);
         LocalDateTime endDateTime = startDateTime.plusMinutes(10);
 
         List<RushEvent> rushEvents = new ArrayList<>();


### PR DESCRIPTION
## 🖥️ Preview

close #{issue number}

## ✏️ 한 일

## ❗️ 발생한 이슈 (해결 방안)

## ❓ 논의가 필요한 사항