### PR TITLE
Feature/#109 admin lottery event delete

### DIFF
--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
@@ -65,9 +65,9 @@ public class AdminController {
     @PostMapping("/event/rush")
     public ResponseEntity<RushEventResponseDto> createRushEvent(
             @RequestPart(value = "dto") RushEventRequestDto rushEventRequestDto,
-            @RequestPart(value = "prizeImg")MultipartFile prizeImg,
-            @RequestPart(value = "leftOptionImg")MultipartFile leftOptionImg,
-            @RequestPart(value = "rightOptionImg")MultipartFile rightOptionImg) {
+            @RequestPart(value = "prizeImg") MultipartFile prizeImg,
+            @RequestPart(value = "leftOptionImg") MultipartFile leftOptionImg,
+            @RequestPart(value = "rightOptionImg") MultipartFile rightOptionImg) {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(adminService.createRushEvent(rushEventRequestDto, prizeImg, leftOptionImg, rightOptionImg));
@@ -75,9 +75,16 @@ public class AdminController {
 
     // 선착순 이벤트 전체 조회
     @GetMapping("/event/rush")
-    public ResponseEntity<List<AdminRushEventResponseDto>> getRushEvents(){
+    public ResponseEntity<List<AdminRushEventResponseDto>> getRushEvents() {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(adminService.getRushEvents());
+    }
+
+    // 추첨 이벤트 삭제
+    @DeleteMapping("/event/lottery")
+    public ResponseEntity<Void> deleteLotteryEvent() {
+        adminService.deleteLotteryEvent();
+        return ResponseEntity.noContent().build(); // 204 No Content
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/repository/AdminRepository.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/repository/AdminRepository.java
@@ -4,6 +4,9 @@ import JGS.CasperEvent.domain.event.entity.admin.Admin;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface AdminRepository extends JpaRepository<Admin, String> {
+    Optional<Admin> findByIdAndPassword(String id, String password);
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
@@ -162,7 +162,7 @@ public class AdminService {
         }
 
         if (lotteryEventList.size() > 1) {
-            throw new CustomException("현재 진행중인 lotteryEvent가 1개 이상입니다.", CustomErrorCode.TOO_MANY_LOTTERY_EVENT);
+            throw new CustomException("현재 진행중인 lotteryEvent가 2개 이상입니다.", CustomErrorCode.TOO_MANY_LOTTERY_EVENT);
         }
 
         lotteryEventRepository.deleteAll();

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
@@ -52,7 +52,7 @@ public class AdminService {
     private final S3Service s3Service;
 
     public Admin verifyAdmin(AdminRequestDto adminRequestDto) {
-        return adminRepository.findById(adminRequestDto.getAdminId()).orElseThrow(NoSuchElementException::new);
+        return adminRepository.findByIdAndPassword(adminRequestDto.getAdminId(), adminRequestDto.getPassword()).orElseThrow(NoSuchElementException::new);
     }
 
     public ResponseDto postAdmin(AdminRequestDto adminRequestDto) {
@@ -152,5 +152,19 @@ public class AdminService {
     public List<AdminRushEventResponseDto> getRushEvents(){
         List<RushEvent> rushEvents = rushEventRepository.findAll();
         return AdminRushEventResponseDto.of(rushEvents);
+    }
+
+    public void deleteLotteryEvent() {
+        List<LotteryEvent> lotteryEventList = lotteryEventRepository.findAll();
+
+        if (lotteryEventList.isEmpty()) {
+            throw new CustomException("현재 진행중인 lotteryEvent가 존재하지 않습니다.", CustomErrorCode.NO_LOTTERY_EVENT);
+        }
+
+        if (lotteryEventList.size() > 1) {
+            throw new CustomException("현재 진행중인 lotteryEvent가 1개 이상입니다.", CustomErrorCode.TOO_MANY_LOTTERY_EVENT);
+        }
+
+        lotteryEventRepository.deleteAll();
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/LotteryEventService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/LotteryEventService.java
@@ -54,7 +54,7 @@ public class LotteryEventService {
         }
 
         if (lotteryEventList.size() > 1) {
-            throw new CustomException("현재 진행중인 lotteryEvent가 1개 이상입니다.", CustomErrorCode.TOO_MANY_LOTTERY_EVENT);
+            throw new CustomException("현재 진행중인 lotteryEvent가 2개 이상입니다.", CustomErrorCode.TOO_MANY_LOTTERY_EVENT);
         }
 
         LotteryEvent lotteryEvent = lotteryEventList.get(0);
@@ -119,7 +119,7 @@ public class LotteryEventService {
         }
 
         if (lotteryEventList.size() > 1) {
-            throw new CustomException("현재 진행중인 lotteryEvent가 1개 이상입니다.", CustomErrorCode.TOO_MANY_LOTTERY_EVENT);
+            throw new CustomException("현재 진행중인 lotteryEvent가 2개 이상입니다.", CustomErrorCode.TOO_MANY_LOTTERY_EVENT);
         }
 
         LotteryEvent lotteryEvent = lotteryEventList.get(0);

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/LotteryEventService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/LotteryEventService.java
@@ -29,6 +29,7 @@ import java.nio.file.attribute.UserPrincipalNotFoundException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -45,7 +46,18 @@ public class LotteryEventService {
 
     public CasperBotResponseDto postCasperBot(BaseUser user, CasperBotRequestDto casperBotRequestDto) throws CustomException, NoSuchPaddingException, IllegalBlockSizeException, NoSuchAlgorithmException, BadPaddingException, InvalidKeyException {
         LotteryParticipants participants = registerUserIfNeed(user, casperBotRequestDto);
-        LotteryEvent lotteryEvent = lotteryEventRepository.findById(1L).orElseThrow(LotteryEventNotExists::new);
+
+        List<LotteryEvent> lotteryEventList = lotteryEventRepository.findAll();
+
+        if (lotteryEventList.isEmpty()) {
+            throw new CustomException("현재 진행중인 lotteryEvent가 존재하지 않습니다.", CustomErrorCode.NO_LOTTERY_EVENT);
+        }
+
+        if (lotteryEventList.size() > 1) {
+            throw new CustomException("현재 진행중인 lotteryEvent가 1개 이상입니다.", CustomErrorCode.TOO_MANY_LOTTERY_EVENT);
+        }
+
+        LotteryEvent lotteryEvent = lotteryEventList.get(0);
 
         CasperBot casperBot = casperBotRepository.save(new CasperBot(casperBotRequestDto, user.getId()));
         lotteryEvent.addAppliedCount();
@@ -100,8 +112,17 @@ public class LotteryEventService {
     }
 
     public LotteryEventResponseDto getLotteryEvent() {
-        LotteryEvent lotteryEvent = lotteryEventRepository.findById(1L).orElseThrow(LotteryEventNotExists::new);
+        List<LotteryEvent> lotteryEventList = lotteryEventRepository.findAll();
+
+        if (lotteryEventList.isEmpty()) {
+            throw new CustomException("현재 진행중인 lotteryEvent가 존재하지 않습니다.", CustomErrorCode.NO_LOTTERY_EVENT);
+        }
+
+        if (lotteryEventList.size() > 1) {
+            throw new CustomException("현재 진행중인 lotteryEvent가 1개 이상입니다.", CustomErrorCode.TOO_MANY_LOTTERY_EVENT);
+        }
+
+        LotteryEvent lotteryEvent = lotteryEventList.get(0);
         return LotteryEventResponseDto.of(lotteryEvent, LocalDateTime.now());
     }
-
 }

--- a/Server/src/main/java/JGS/CasperEvent/global/enums/CustomErrorCode.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/enums/CustomErrorCode.java
@@ -22,7 +22,8 @@ public enum CustomErrorCode {
     LOTTERY_EVENT_ALREADY_EXISTS("추첨 이벤트가 이미 존재합니다.", 409),
     INVALID_RUSH_EVENT_OPTIONS_COUNT("이벤트의 옵션 수가 올바르지 않습니다.", 500),
     INVALID_RUSH_EVENT_OPTION_ID("옵션 ID는 1 또는 2여야 합니다.", 400),
-    EMPTY_FILE("유효하지 않은 파일입니다.", 422);
+    EMPTY_FILE("유효하지 않은 파일입니다.", 422),
+    TOO_MANY_LOTTERY_EVENT("현재 진행중인 추첨 이벤트가 2개 이상입니다.", 409);
 
     private final String message;
     private int status;


### PR DESCRIPTION
## 🖥️ Preview

close #{109}

## ✏️ 한 일
* 기존 lotteryEvent를 조회할 때 무조건 id 값이 1인 이벤트를 조회하는 로직을 수정
* 추첨 이벤트 삭제 API 구현
* Admin 로그인 로직에서 password도 확인하도록 수정

## ❗️ 발생한 이슈 (해결 방안)

## ❓ 논의가 필요한 사항