### PR TITLE
Feature/#116 admin lottery event delete expectation

### DIFF
--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
@@ -138,4 +138,12 @@ public class AdminController {
 
         return ResponseEntity.ok(lotteryEventExpectationResponseDtoList);
     }
+
+    // 추첨 이벤트 특정 기대평을 삭제
+    @PatchMapping("/event/lottery/expecations/{casperId}")
+    public ResponseEntity<Void> deleteLotteryEventExpectation(@PathVariable("casperId") Long casperId) {
+        adminService.deleteLotteryEventExpectation(casperId);
+
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/lotteryEventResponseDto/LotteryEventExpectationResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/lotteryEventResponseDto/LotteryEventExpectationResponseDto.java
@@ -6,7 +6,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
-public record LotteryEventExpectationResponseDto(String expectation, LocalDate createdDate,
+public record LotteryEventExpectationResponseDto(Long casperId, String expectation, LocalDate createdDate,
                                                  LocalTime createdTime) {
 
     public static LotteryEventExpectationResponseDto of(CasperBot casperBot) {
@@ -16,6 +16,7 @@ public record LotteryEventExpectationResponseDto(String expectation, LocalDate c
         LocalTime createdTime = createdAt.toLocalTime();
 
         return new LotteryEventExpectationResponseDto(
+                casperBot.getCasperId(),
                 casperBot.getExpectation(),
                 createdDate,
                 createdTime

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/entity/casperBot/CasperBot.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/entity/casperBot/CasperBot.java
@@ -40,4 +40,16 @@ public class CasperBot extends BaseEntity {
         this.name = requestDto.getName();
         this.expectation = requestDto.getExpectation();
     }
+
+    public CasperBot deleteExpectation() {
+        if (!this.expectation.isEmpty()) {
+            this.expectation = "삭제된 기대평입니다.";
+        }
+
+        return this;
+    }
+
+    public boolean isDeleted() {
+        return this.expectation.equals("삭제된 기대평입니다.");
+    }
 }


### PR DESCRIPTION
## 🖥️ Preview

close #116 

## ✏️ 한 일
* 특정 기대평을 삭제하는 API 구현
* 선착순 이벤트 업데이트 메서드에 @Transactional 애노테이션 추가
* 특정 유저가 작성한 기대평 조회할 때, 작성 안한 기대평 및 삭제된 기대평은 조회하지 않도록 구현
* 기대평 조회할 때 CasperId 필드도 반환하도록 변경

## ❗️ 발생한 이슈 (해결 방안)

## ❓ 논의가 필요한 사항
@Transactinal 애노테이션과 JPA 영속성 컨텍스트에 대해서 같이 의논해보면 좋을 것 같습니다.