### PR TITLE
0816 Pull

### DIFF
--- a/Server/build.gradle
+++ b/Server/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-parameter-store'
     implementation 'mysql:mysql-connector-java:8.0.33'  // MySQL JDBC 드라이버 추가
     implementation 'org.springframework.boot:spring-boot-starter-aop'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
@@ -10,6 +10,7 @@ import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.Lott
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventParticipantsListResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.AdminRushEventOptionResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.AdminRushEventResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.LotteryEventWinnerListResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.RushEventParticipantsListResponseDto;
 import JGS.CasperEvent.domain.event.repository.eventRepository.LotteryEventRepository;
 import JGS.CasperEvent.domain.event.service.adminService.AdminService;
@@ -28,7 +29,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AdminController {
     private final AdminService adminService;
-    private final LotteryEventRepository lotteryEventRepository;
 
     // 어드민 생성
     @PostMapping("/join")
@@ -179,9 +179,20 @@ public class AdminController {
 
     // 추첨 이벤트 당첨자 추첨
     @PostMapping("/event/lottery/winner")
-    public ResponseEntity<ResponseDto> pickWinners(){
+    public ResponseEntity<ResponseDto> pickLotteryEventWinners() {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(adminService.pickWinners());
+                .body(adminService.pickLotteryEventWinners());
+    }
+
+    // 추첨 이벤트 당첨자 조회
+    @GetMapping("/event/lottery/winner")
+    public ResponseEntity<LotteryEventWinnerListResponseDto> getWinners(
+            @RequestParam(name = "size", required = false, defaultValue = "10") int size,
+            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "number", required = false, defaultValue = "") String phoneNumber) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(adminService.getLotteryEventWinners(size, page, phoneNumber));
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
@@ -160,7 +160,7 @@ public class AdminController {
     }
 
     // 추첨 이벤트 특정 기대평을 삭제
-    @PatchMapping("/event/lottery/expecations/{casperId}")
+    @PatchMapping("/event/lottery/expectations/{casperId}")
     public ResponseEntity<Void> deleteLotteryEventExpectation(@PathVariable("casperId") Long casperId) {
         adminService.deleteLotteryEventExpectation(casperId);
 

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
@@ -8,11 +8,10 @@ import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.Lott
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventExpectationResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventParticipantsListResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.AdminRushEventOptionResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.AdminRushEventResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.RushEventParticipantsListResponseDto;
 import JGS.CasperEvent.domain.event.repository.eventRepository.LotteryEventRepository;
-
-
 import JGS.CasperEvent.domain.event.service.adminService.AdminService;
 import JGS.CasperEvent.global.response.ResponseDto;
 import jakarta.validation.Valid;
@@ -30,6 +29,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AdminController {
     private final AdminService adminService;
+    private final LotteryEventRepository lotteryEventRepository;
 
     // 어드민 생성
     @PostMapping("/join")
@@ -123,10 +123,18 @@ public class AdminController {
     @DeleteMapping("/event/rush/{rushEventId}")
     public ResponseEntity<ResponseDto> deleteRushEvent(@PathVariable Long rushEventId){
         return ResponseEntity
-                .status(HttpStatusCode.OK)
+                .status(HttpStatus.OK)
                 .body(adminService.deleteRushEvent(rushEventId));
     }
 
+    // 선착순 이벤트 선택지 조회
+    @GetMapping("/event/rush/{rushEventId}/options")
+    public ResponseEntity<AdminRushEventOptionResponseDto> getRushEventOptions(@PathVariable Long rushEventId) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(adminService.getRushEventOptions(rushEventId));
+    }
+  
     // 추첨 이벤트 삭제
     @DeleteMapping("/event/lottery")
     public ResponseEntity<Void> deleteLotteryEvent() {

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
@@ -2,6 +2,7 @@ package JGS.CasperEvent.domain.event.controller.adminController;
 
 import JGS.CasperEvent.domain.event.dto.RequestDto.AdminRequestDto;
 import JGS.CasperEvent.domain.event.dto.RequestDto.LotteryEventRequestDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.LotteryEventDetailResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.LotteryEventResponseDto;
 import JGS.CasperEvent.domain.event.service.adminService.AdminService;
 import JGS.CasperEvent.global.response.ResponseDto;
@@ -10,6 +11,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/admin")
@@ -28,6 +31,13 @@ public class AdminController {
                 .body(adminService.postAdmin(adminRequestDto));
     }
 
+    @GetMapping("/event/lottery")
+    public ResponseEntity<List<LotteryEventDetailResponseDto>> getLotteryEvent() {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(adminService.getLotteryEvent());
+    }
+
     @PostMapping("/event/lottery")
     public ResponseEntity<LotteryEventResponseDto> createLotteryEvent(
             @Valid @RequestBody  LotteryEventRequestDto lotteryEventRequestDto) {
@@ -35,4 +45,5 @@ public class AdminController {
                 .status(HttpStatus.CREATED)
                 .body(adminService.createLotteryEvent(lotteryEventRequestDto));
     }
+
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
@@ -4,10 +4,7 @@ import JGS.CasperEvent.domain.event.dto.RequestDto.AdminRequestDto;
 import JGS.CasperEvent.domain.event.dto.RequestDto.lotteryEventDto.LotteryEventRequestDto;
 import JGS.CasperEvent.domain.event.dto.RequestDto.rushEventDto.RushEventRequestDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.ImageUrlResponseDto;
-import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventDetailResponseDto;
-import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventExpectationResponseDto;
-import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventResponseDto;
-import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventParticipantsListResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.*;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.AdminRushEventOptionResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.AdminRushEventResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.LotteryEventWinnerListResponseDto;
@@ -162,8 +159,10 @@ public class AdminController {
 
     // 추첨 이벤트 특정 사용자의 기대평 조회
     @GetMapping("/event/lottery/participants/{participantId}/expectations")
-    public ResponseEntity<List<LotteryEventExpectationResponseDto>> getLotteryEventExpectations(@PathVariable("participantId") Long participantId) {
-        List<LotteryEventExpectationResponseDto> lotteryEventExpectationResponseDtoList = adminService.getLotteryEventExpectations(participantId);
+    public ResponseEntity<LotteryEventExpectationsResponseDto> getLotteryEventExpectations(@PathVariable("participantId") Long participantId,
+                                                                                                @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+                                                                                                @RequestParam(name = "size", required = false, defaultValue = "10") int size) {
+        LotteryEventExpectationsResponseDto lotteryEventExpectationResponseDtoList = adminService.getLotteryEventExpectations(page, size, participantId);
 
         return ResponseEntity.ok(lotteryEventExpectationResponseDtoList);
     }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
@@ -8,7 +8,7 @@ import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.Lott
 import JGS.CasperEvent.domain.event.service.adminService.AdminService;
 import JGS.CasperEvent.global.response.ResponseDto;
 import jakarta.validation.Valid;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -17,13 +17,9 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/admin")
+@RequiredArgsConstructor
 public class AdminController {
     private final AdminService adminService;
-
-    @Autowired
-    public AdminController(AdminService adminService) {
-        this.adminService = adminService;
-    }
 
     // 어드민 생성
     @PostMapping("/join")

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
@@ -9,6 +9,7 @@ import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.Lott
 import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.AdminRushEventResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.RushEventParticipantsListResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.RushEventResponseDto;
+import JGS.CasperEvent.domain.event.repository.eventRepository.LotteryEventRepository;
 import JGS.CasperEvent.domain.event.service.adminService.AdminService;
 import JGS.CasperEvent.global.response.ResponseDto;
 import jakarta.validation.Valid;
@@ -25,6 +26,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AdminController {
     private final AdminService adminService;
+    private final LotteryEventRepository lotteryEventRepository;
 
     // 어드민 생성
     @PostMapping("/join")
@@ -102,5 +104,13 @@ public class AdminController {
         adminService.deleteLotteryEvent();
         return ResponseEntity.noContent().build(); // 204 No Content
 
+    }
+
+    // 추첨 이벤트 수정
+    @PutMapping("/event/lottery")
+    public ResponseEntity<LotteryEventDetailResponseDto> updateLotteryEvent(@RequestBody @Valid LotteryEventRequestDto lotteryEventRequestDto) {
+        LotteryEventDetailResponseDto updatedLotteryEventDetailResponseDto = adminService.updateLotteryEvent(lotteryEventRequestDto);
+
+        return ResponseEntity.ok(updatedLotteryEventDetailResponseDto);
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
@@ -3,6 +3,7 @@ package JGS.CasperEvent.domain.event.controller.adminController;
 import JGS.CasperEvent.domain.event.dto.RequestDto.AdminRequestDto;
 import JGS.CasperEvent.domain.event.dto.RequestDto.lotteryEventDto.LotteryEventRequestDto;
 import JGS.CasperEvent.domain.event.dto.RequestDto.rushEventDto.RushEventRequestDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.ImageUrlResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventDetailResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventParticipantsListResponseDto;
@@ -34,6 +35,16 @@ public class AdminController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(adminService.postAdmin(adminRequestDto));
+    }
+
+    // 이미지 업로드
+    @PostMapping("/image")
+    public ResponseEntity<ImageUrlResponseDto> postImage(
+            @RequestPart(value = "image") MultipartFile image){
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(adminService.postImage(image));
+
     }
 
     // 추첨 이벤트 조회
@@ -84,7 +95,6 @@ public class AdminController {
                 .body(adminService.getRushEvents());
     }
 
-
     // 선착순 이벤트 참여자 조회
     @GetMapping("/event/rush/{rushEventId}/participants")
     public ResponseEntity<RushEventParticipantsListResponseDto> getRushEventParticipants(
@@ -96,6 +106,17 @@ public class AdminController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(adminService.getRushEventParticipants(rushEventId, size, page, option, phoneNumber));
+    }
+
+    // 선착순 이벤트 수정
+    @PutMapping("/event/rush")
+    public ResponseEntity<List<AdminRushEventResponseDto>> updateRushEvent(
+            @RequestPart(name = "json") List<RushEventRequestDto> rushEventListRequestDto,
+            @RequestPart(name = "images") List<MultipartFile> images
+    ) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(adminService.updateRushEvents(rushEventListRequestDto, images));
     }
 
     // 추첨 이벤트 삭제

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
@@ -10,6 +10,9 @@ import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.Lott
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventParticipantsListResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.AdminRushEventResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.RushEventParticipantsListResponseDto;
+import JGS.CasperEvent.domain.event.repository.eventRepository.LotteryEventRepository;
+
+
 import JGS.CasperEvent.domain.event.service.adminService.AdminService;
 import JGS.CasperEvent.global.response.ResponseDto;
 import jakarta.validation.Valid;
@@ -18,6 +21,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.http.HttpStatusCode;
 
 import java.util.List;
 
@@ -113,6 +117,14 @@ public class AdminController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(adminService.updateRushEvents(rushEventListRequestDto));
+    }
+
+    // 선착순 이벤트 삭제
+    @DeleteMapping("/event/rush/{rushEventId}")
+    public ResponseEntity<ResponseDto> deleteRushEvent(@PathVariable Long rushEventId){
+        return ResponseEntity
+                .status(HttpStatusCode.OK)
+                .body(adminService.deleteRushEvent(rushEventId));
     }
 
     // 추첨 이벤트 삭제

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
@@ -65,9 +65,9 @@ public class AdminController {
     @PostMapping("/event/rush")
     public ResponseEntity<RushEventResponseDto> createRushEvent(
             @RequestPart(value = "dto") RushEventRequestDto rushEventRequestDto,
-            @RequestPart(value = "prizeImg")MultipartFile prizeImg,
-            @RequestPart(value = "leftOptionImg")MultipartFile leftOptionImg,
-            @RequestPart(value = "rightOptionImg")MultipartFile rightOptionImg) {
+            @RequestPart(value = "prizeImg") MultipartFile prizeImg,
+            @RequestPart(value = "leftOptionImg") MultipartFile leftOptionImg,
+            @RequestPart(value = "rightOptionImg") MultipartFile rightOptionImg) {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(adminService.createRushEvent(rushEventRequestDto, prizeImg, leftOptionImg, rightOptionImg));
@@ -75,9 +75,16 @@ public class AdminController {
 
     // 선착순 이벤트 전체 조회
     @GetMapping("/event/rush")
-    public ResponseEntity<List<AdminRushEventResponseDto>> getRushEvents(){
+    public ResponseEntity<List<AdminRushEventResponseDto>> getRushEvents() {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(adminService.getRushEvents());
+    }
+
+    // 추첨 이벤트 삭제
+    @DeleteMapping("/event/lottery")
+    public ResponseEntity<Void> deleteLotteryEvent() {
+        adminService.deleteLotteryEvent();
+        return ResponseEntity.noContent().build(); // 204 No Content
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
@@ -138,4 +138,12 @@ public class AdminController {
 
         return ResponseEntity.ok(lotteryEventExpectationResponseDtoList);
     }
+
+    // 추첨 이벤트 특정 기대평을 삭제
+    @PatchMapping("/event/lottery/expecations/{casperId}")
+    public ResponseEntity<Void> deleteLotteryEventExpectation(@PathVariable("casperId") Long casperId) {
+        adminService.deleteLotteryEventExpectation(casperId);
+
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
@@ -5,12 +5,11 @@ import JGS.CasperEvent.domain.event.dto.RequestDto.lotteryEventDto.LotteryEventR
 import JGS.CasperEvent.domain.event.dto.RequestDto.rushEventDto.RushEventRequestDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.ImageUrlResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventDetailResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventExpectationResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventParticipantsListResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.AdminRushEventResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.RushEventParticipantsListResponseDto;
-import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.RushEventResponseDto;
-import JGS.CasperEvent.domain.event.repository.eventRepository.LotteryEventRepository;
 import JGS.CasperEvent.domain.event.service.adminService.AdminService;
 import JGS.CasperEvent.global.response.ResponseDto;
 import jakarta.validation.Valid;
@@ -27,7 +26,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class AdminController {
     private final AdminService adminService;
-    private final LotteryEventRepository lotteryEventRepository;
 
     // 어드민 생성
     @PostMapping("/join")
@@ -131,5 +129,13 @@ public class AdminController {
         LotteryEventDetailResponseDto updatedLotteryEventDetailResponseDto = adminService.updateLotteryEvent(lotteryEventRequestDto);
 
         return ResponseEntity.ok(updatedLotteryEventDetailResponseDto);
+    }
+
+    // 추첨 이벤트 특정 사용자의 기대평 조회
+    @GetMapping("/event/lottery/participants/{participantId}/expectations")
+    public ResponseEntity<List<LotteryEventExpectationResponseDto>> getLotteryEventExpectations(@PathVariable("participantId") Long participantId) {
+        List<LotteryEventExpectationResponseDto> lotteryEventExpectationResponseDtoList = adminService.getLotteryEventExpectations(participantId);
+
+        return ResponseEntity.ok(lotteryEventExpectationResponseDtoList);
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
@@ -2,8 +2,9 @@ package JGS.CasperEvent.domain.event.controller.adminController;
 
 import JGS.CasperEvent.domain.event.dto.RequestDto.AdminRequestDto;
 import JGS.CasperEvent.domain.event.dto.RequestDto.LotteryEventRequestDto;
-import JGS.CasperEvent.domain.event.dto.ResponseDto.LotteryEventDetailResponseDto;
-import JGS.CasperEvent.domain.event.dto.ResponseDto.LotteryEventResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventDetailResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventParticipantsListResponseDto;
 import JGS.CasperEvent.domain.event.service.adminService.AdminService;
 import JGS.CasperEvent.global.response.ResponseDto;
 import jakarta.validation.Valid;
@@ -24,6 +25,7 @@ public class AdminController {
         this.adminService = adminService;
     }
 
+    // 어드민 생성
     @PostMapping("/join")
     public ResponseEntity<ResponseDto> postAdmin(@RequestBody @Valid AdminRequestDto adminRequestDto) {
         return ResponseEntity
@@ -31,6 +33,7 @@ public class AdminController {
                 .body(adminService.postAdmin(adminRequestDto));
     }
 
+    // 추첨 이벤트 조회
     @GetMapping("/event/lottery")
     public ResponseEntity<List<LotteryEventDetailResponseDto>> getLotteryEvent() {
         return ResponseEntity
@@ -38,12 +41,23 @@ public class AdminController {
                 .body(adminService.getLotteryEvent());
     }
 
+    // 추첨 이벤트 생성
     @PostMapping("/event/lottery")
     public ResponseEntity<LotteryEventResponseDto> createLotteryEvent(
-            @Valid @RequestBody  LotteryEventRequestDto lotteryEventRequestDto) {
+            @Valid @RequestBody LotteryEventRequestDto lotteryEventRequestDto) {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(adminService.createLotteryEvent(lotteryEventRequestDto));
     }
 
+    // 추첨 이벤트 참여자 조회
+    @GetMapping("/event/lottery/participants")
+    public ResponseEntity<LotteryEventParticipantsListResponseDto> getLotteryEventParticipants(
+            @RequestParam(name = "size", required = false, defaultValue = "10") int size,
+            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "number", required = false, defaultValue = "") String phoneNumber) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(adminService.getLotteryEventParticipants(size, page, phoneNumber));
+    }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
@@ -6,6 +6,7 @@ import JGS.CasperEvent.domain.event.dto.RequestDto.rushEventDto.RushEventRequest
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventDetailResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventParticipantsListResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.AdminRushEventResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.RushEventResponseDto;
 import JGS.CasperEvent.domain.event.service.adminService.AdminService;
 import JGS.CasperEvent.global.response.ResponseDto;
@@ -70,5 +71,13 @@ public class AdminController {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(adminService.createRushEvent(rushEventRequestDto, prizeImg, leftOptionImg, rightOptionImg));
+    }
+
+    // 선착순 이벤트 전체 조회
+    @GetMapping("/event/rush")
+    public ResponseEntity<List<AdminRushEventResponseDto>> getRushEvents(){
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(adminService.getRushEvents());
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
@@ -77,7 +77,7 @@ public class AdminController {
 
     // 선착순 이벤트 생성
     @PostMapping("/event/rush")
-    public ResponseEntity<RushEventResponseDto> createRushEvent(
+    public ResponseEntity<AdminRushEventResponseDto> createRushEvent(
             @RequestPart(value = "dto") RushEventRequestDto rushEventRequestDto,
             @RequestPart(value = "prizeImg") MultipartFile prizeImg,
             @RequestPart(value = "leftOptionImg") MultipartFile leftOptionImg,
@@ -111,12 +111,10 @@ public class AdminController {
     // 선착순 이벤트 수정
     @PutMapping("/event/rush")
     public ResponseEntity<List<AdminRushEventResponseDto>> updateRushEvent(
-            @RequestPart(name = "json") List<RushEventRequestDto> rushEventListRequestDto,
-            @RequestPart(name = "images") List<MultipartFile> images
-    ) {
+            @RequestBody List<RushEventRequestDto> rushEventListRequestDto) {
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(adminService.updateRushEvents(rushEventListRequestDto, images));
+                .body(adminService.updateRushEvents(rushEventListRequestDto));
     }
 
     // 추첨 이벤트 삭제

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
@@ -183,12 +183,21 @@ public class AdminController {
                 .body(adminService.pickLotteryEventWinners());
     }
 
+    // 추첨 이벤트 당첨자 삭제
+    @DeleteMapping("/event/lottery/winner")
+    public ResponseEntity<ResponseDto> deleteLotteryEventWinners(){
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(adminService.deleteLotteryEventWinners());
+    }
+
     // 추첨 이벤트 당첨자 조회
     @GetMapping("/event/lottery/winner")
     public ResponseEntity<LotteryEventWinnerListResponseDto> getWinners(
             @RequestParam(name = "size", required = false, defaultValue = "10") int size,
             @RequestParam(name = "page", required = false, defaultValue = "0") int page,
             @RequestParam(name = "number", required = false, defaultValue = "") String phoneNumber) {
+
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(adminService.getLotteryEventWinners(size, page, phoneNumber));

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
@@ -1,7 +1,7 @@
 package JGS.CasperEvent.domain.event.controller.adminController;
 
 import JGS.CasperEvent.domain.event.dto.RequestDto.AdminRequestDto;
-import JGS.CasperEvent.domain.event.dto.RequestDto.LotteryEventRequestDto;
+import JGS.CasperEvent.domain.event.dto.RequestDto.lotteryEventDto.LotteryEventRequestDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventDetailResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventParticipantsListResponseDto;

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
@@ -7,6 +7,7 @@ import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.Lott
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventParticipantsListResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.AdminRushEventResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.RushEventParticipantsListResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.RushEventResponseDto;
 import JGS.CasperEvent.domain.event.service.adminService.AdminService;
 import JGS.CasperEvent.global.response.ResponseDto;
@@ -35,7 +36,7 @@ public class AdminController {
 
     // 추첨 이벤트 조회
     @GetMapping("/event/lottery")
-    public ResponseEntity<List<LotteryEventDetailResponseDto>> getLotteryEvent() {
+    public ResponseEntity<LotteryEventDetailResponseDto> getLotteryEvent() {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(adminService.getLotteryEvent());
@@ -81,10 +82,25 @@ public class AdminController {
                 .body(adminService.getRushEvents());
     }
 
+
+    // 선착순 이벤트 참여자 조회
+    @GetMapping("/event/rush/{rushEventId}/participants")
+    public ResponseEntity<RushEventParticipantsListResponseDto> getRushEventParticipants(
+            @PathVariable("rushEventId") Long rushEventId,
+            @RequestParam(name = "size", required = false, defaultValue = "10") int size,
+            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "option", required = false, defaultValue = "0") int option,
+            @RequestParam(name = "number", required = false, defaultValue = "") String phoneNumber) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(adminService.getRushEventParticipants(rushEventId, size, page, option, phoneNumber));
+    }
+
     // 추첨 이벤트 삭제
     @DeleteMapping("/event/lottery")
     public ResponseEntity<Void> deleteLotteryEvent() {
         adminService.deleteLotteryEvent();
         return ResponseEntity.noContent().build(); // 204 No Content
+
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
@@ -12,7 +12,6 @@ import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.AdminRu
 import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.AdminRushEventResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.LotteryEventWinnerListResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.RushEventParticipantsListResponseDto;
-import JGS.CasperEvent.domain.event.repository.eventRepository.LotteryEventRepository;
 import JGS.CasperEvent.domain.event.service.adminService.AdminService;
 import JGS.CasperEvent.global.response.ResponseDto;
 import jakarta.validation.Valid;

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
@@ -20,7 +20,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-import software.amazon.awssdk.http.HttpStatusCode;
 
 import java.util.List;
 
@@ -41,12 +40,10 @@ public class AdminController {
 
     // 이미지 업로드
     @PostMapping("/image")
-    public ResponseEntity<ImageUrlResponseDto> postImage(
-            @RequestPart(value = "image") MultipartFile image){
+    public ResponseEntity<ImageUrlResponseDto> postImage(@RequestPart(value = "image") MultipartFile image) {
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(adminService.postImage(image));
-
     }
 
     // 추첨 이벤트 조회
@@ -110,10 +107,23 @@ public class AdminController {
                 .body(adminService.getRushEventParticipants(rushEventId, size, page, option, phoneNumber));
     }
 
+    // 선착순 이벤트 당첨자 조회
+    @GetMapping("/event/rush/{rushEventId}/winner")
+    public ResponseEntity<RushEventParticipantsListResponseDto> getRushEventWinners(
+            @PathVariable("rushEventId") Long rushEventId,
+            @RequestParam(name = "size", required = false, defaultValue = "10") int size,
+            @RequestParam(name = "page", required = false, defaultValue = "0") int page,
+            @RequestParam(name = "number", required = false, defaultValue = "") String phoneNumber) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(adminService.getRushEventWinners(rushEventId, size, page, phoneNumber));
+    }
+
     // 선착순 이벤트 수정
     @PutMapping("/event/rush")
     public ResponseEntity<List<AdminRushEventResponseDto>> updateRushEvent(
             @RequestBody List<RushEventRequestDto> rushEventListRequestDto) {
+
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(adminService.updateRushEvents(rushEventListRequestDto));
@@ -121,7 +131,7 @@ public class AdminController {
 
     // 선착순 이벤트 삭제
     @DeleteMapping("/event/rush/{rushEventId}")
-    public ResponseEntity<ResponseDto> deleteRushEvent(@PathVariable Long rushEventId){
+    public ResponseEntity<ResponseDto> deleteRushEvent(@PathVariable Long rushEventId) {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(adminService.deleteRushEvent(rushEventId));

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
@@ -144,7 +144,7 @@ public class AdminController {
                 .status(HttpStatus.OK)
                 .body(adminService.getRushEventOptions(rushEventId));
     }
-  
+
     // 추첨 이벤트 삭제
     @DeleteMapping("/event/lottery")
     public ResponseEntity<Void> deleteLotteryEvent() {
@@ -175,5 +175,13 @@ public class AdminController {
         adminService.deleteLotteryEventExpectation(casperId);
 
         return ResponseEntity.noContent().build();
+    }
+
+    // 추첨 이벤트 당첨자 추첨
+    @PostMapping("/event/lottery/winner")
+    public ResponseEntity<ResponseDto> pickWinners(){
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(adminService.pickWinners());
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/adminController/AdminController.java
@@ -2,9 +2,11 @@ package JGS.CasperEvent.domain.event.controller.adminController;
 
 import JGS.CasperEvent.domain.event.dto.RequestDto.AdminRequestDto;
 import JGS.CasperEvent.domain.event.dto.RequestDto.lotteryEventDto.LotteryEventRequestDto;
+import JGS.CasperEvent.domain.event.dto.RequestDto.rushEventDto.RushEventRequestDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventDetailResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventParticipantsListResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.RushEventResponseDto;
 import JGS.CasperEvent.domain.event.service.adminService.AdminService;
 import JGS.CasperEvent.global.response.ResponseDto;
 import jakarta.validation.Valid;
@@ -12,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -55,5 +58,17 @@ public class AdminController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(adminService.getLotteryEventParticipants(size, page, phoneNumber));
+    }
+
+    // 선착순 이벤트 생성
+    @PostMapping("/event/rush")
+    public ResponseEntity<RushEventResponseDto> createRushEvent(
+            @RequestPart(value = "dto") RushEventRequestDto rushEventRequestDto,
+            @RequestPart(value = "prizeImg")MultipartFile prizeImg,
+            @RequestPart(value = "leftOptionImg")MultipartFile leftOptionImg,
+            @RequestPart(value = "rightOptionImg")MultipartFile rightOptionImg) {
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(adminService.createRushEvent(rushEventRequestDto, prizeImg, leftOptionImg, rightOptionImg));
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/eventController/EventController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/eventController/EventController.java
@@ -1,0 +1,24 @@
+package JGS.CasperEvent.domain.event.controller.eventController;
+
+
+import JGS.CasperEvent.domain.event.dto.ResponseDto.TotalEventDateResponseDto;
+import JGS.CasperEvent.domain.event.service.eventService.EventService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/event")
+
+public class EventController {
+    private final EventService eventService;
+
+    @GetMapping("/total")
+    public ResponseEntity<TotalEventDateResponseDto> getTotalEventDate() {
+        TotalEventDateResponseDto totalEventDateResponseDto = eventService.getTotalEventDate();
+        return ResponseEntity.ok(totalEventDateResponseDto);
+    }
+}

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/eventController/LotteryEventController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/eventController/LotteryEventController.java
@@ -69,12 +69,4 @@ public class LotteryEventController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(redisService.getRecentData());
     }
-
-    // 캐스퍼 봇 조회 API
-    @GetMapping("/{casperId}")
-    public ResponseEntity<CasperBotResponseDto> getCasperBot(@PathVariable String casperId) {
-        return ResponseEntity
-                .status(HttpStatus.OK)
-                .body(lotteryEventService.getCasperBot(Long.parseLong(casperId)));
-    }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/eventController/LotteryEventController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/eventController/LotteryEventController.java
@@ -1,6 +1,6 @@
 package JGS.CasperEvent.domain.event.controller.eventController;
 
-import JGS.CasperEvent.domain.event.dto.RequestDto.CasperBotRequestDto;
+import JGS.CasperEvent.domain.event.dto.RequestDto.lotteryEventDto.CasperBotRequestDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.CasperBotResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryParticipantResponseDto;

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/eventController/LotteryEventController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/eventController/LotteryEventController.java
@@ -1,9 +1,9 @@
 package JGS.CasperEvent.domain.event.controller.eventController;
 
 import JGS.CasperEvent.domain.event.dto.RequestDto.CasperBotRequestDto;
-import JGS.CasperEvent.domain.event.dto.ResponseDto.CasperBotResponseDto;
-import JGS.CasperEvent.domain.event.dto.ResponseDto.LotteryEventResponseDto;
-import JGS.CasperEvent.domain.event.dto.ResponseDto.LotteryParticipantResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.CasperBotResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryParticipantResponseDto;
 import JGS.CasperEvent.domain.event.service.redisService.RedisService;
 import JGS.CasperEvent.domain.event.service.eventService.LotteryEventService;
 import JGS.CasperEvent.global.entity.BaseUser;

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/eventController/LotteryEventController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/eventController/LotteryEventController.java
@@ -34,13 +34,15 @@ public class LotteryEventController {
         this.lotteryEventService = lotteryEventService;
         this.redisService = redisService;
     }
-    // 추첨 이벤트 조회 API  -> 가짜 API
+
+    // 추첨 이벤트 조회 API
     @GetMapping
     public ResponseEntity<LotteryEventResponseDto> getLotteryEvent(){
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(lotteryEventService.getLotteryEvent());
     }
+
     // 캐스퍼 봇 생성 API
     @PostMapping("/casperBot")
     public ResponseEntity<CasperBotResponseDto> postCasperBot(

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/eventController/LotteryEventController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/eventController/LotteryEventController.java
@@ -9,13 +9,17 @@ import JGS.CasperEvent.domain.event.service.eventService.LotteryEventService;
 import JGS.CasperEvent.global.entity.BaseUser;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
-import org.apache.coyote.BadRequestException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.crypto.BadPaddingException;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
 import java.nio.file.attribute.UserPrincipalNotFoundException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
 import java.util.List;
 
 @RestController
@@ -41,7 +45,7 @@ public class LotteryEventController {
     @PostMapping("/casperBot")
     public ResponseEntity<CasperBotResponseDto> postCasperBot(
             HttpServletRequest request,
-            @RequestBody @Valid CasperBotRequestDto postCasperBot) throws BadRequestException {
+            @RequestBody @Valid CasperBotRequestDto postCasperBot) throws NoSuchPaddingException, IllegalBlockSizeException, NoSuchAlgorithmException, BadPaddingException, InvalidKeyException {
         BaseUser user = (BaseUser) request.getAttribute("user");
         return ResponseEntity
                 .status(HttpStatus.CREATED)

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/eventController/RushEventController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/eventController/RushEventController.java
@@ -1,7 +1,7 @@
 package JGS.CasperEvent.domain.event.controller.eventController;
 
 
-import JGS.CasperEvent.domain.event.dto.ResponseDto.*;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.*;
 import JGS.CasperEvent.domain.event.service.eventService.RushEventService;
 import JGS.CasperEvent.global.entity.BaseUser;
 import jakarta.servlet.http.HttpServletRequest;

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/eventController/RushEventController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/eventController/RushEventController.java
@@ -1,9 +1,7 @@
 package JGS.CasperEvent.domain.event.controller.eventController;
 
 
-import JGS.CasperEvent.domain.event.dto.ResponseDto.RushEventListResponseDto;
-import JGS.CasperEvent.domain.event.dto.ResponseDto.RushEventRateResponseDto;
-import JGS.CasperEvent.domain.event.dto.ResponseDto.RushEventResultResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.*;
 import JGS.CasperEvent.domain.event.service.eventService.RushEventService;
 import JGS.CasperEvent.global.entity.BaseUser;
 import jakarta.servlet.http.HttpServletRequest;
@@ -26,34 +24,34 @@ public class RushEventController {
     }
 
     // 밸런스 게임 참여 여부 조회
-    @GetMapping("/{eventId}/applied")
-    public ResponseEntity<Boolean> checkUserParticipationInRushEvent(HttpServletRequest httpServletRequest, @PathVariable("eventId") Long eventId) {
-
+    @GetMapping("/applied")
+    public ResponseEntity<Boolean> checkUserParticipationInRushEvent(HttpServletRequest httpServletRequest) {
         BaseUser user = (BaseUser) httpServletRequest.getAttribute("user");
-        return ResponseEntity.ok(rushEventService.isExists(eventId, user.getId()));
+        return ResponseEntity.ok(rushEventService.isExists(user.getId()));
     }
 
     // 밸런스 게임 응모
-    @PostMapping("/{eventId}/options/{optionId}/apply")
-    public ResponseEntity<Void> applyRushEvent(HttpServletRequest httpServletRequest, @PathVariable("eventId") Long eventId, @PathVariable("optionId") int optionId) {
+    @PostMapping("/options/{optionId}/apply")
+    public ResponseEntity<Void> applyRushEvent(HttpServletRequest httpServletRequest, @PathVariable("optionId") int optionId) {
         BaseUser user = (BaseUser) httpServletRequest.getAttribute("user");
-        rushEventService.apply(user, eventId, optionId);
+        rushEventService.apply(user, optionId);
 
         return ResponseEntity.noContent().build();
     }
 
     // 밸런스 게임 비율 조회
-    @GetMapping("/{eventId}/balance")
-    public ResponseEntity<RushEventRateResponseDto> rushEventRate (@PathVariable("eventId") Long eventId) {
-        RushEventRateResponseDto rushEventRateResponseDto = rushEventService.getRushEventRate(eventId);
+    @GetMapping("/balance")
+    public ResponseEntity<RushEventRateResponseDto> rushEventRate(HttpServletRequest httpServletRequest) {
+        BaseUser user = (BaseUser) httpServletRequest.getAttribute("user");
+        RushEventRateResponseDto rushEventRateResponseDto = rushEventService.getRushEventRate(user);
         return ResponseEntity.ok(rushEventRateResponseDto);
     }
 
     // 밸런스 게임 결과 조회
-    @GetMapping("/{eventId}/result")
-    public ResponseEntity<RushEventResultResponseDto> rushEventResult(HttpServletRequest httpServletRequest, @PathVariable("eventId") Long eventId) {
+    @GetMapping("/result")
+    public ResponseEntity<RushEventResultResponseDto> rushEventResult(HttpServletRequest httpServletRequest) {
         BaseUser user = (BaseUser) httpServletRequest.getAttribute("user");
-        RushEventResultResponseDto result = rushEventService.getRushEventResult(user, eventId);
+        RushEventResultResponseDto result = rushEventService.getRushEventResult(user);
         return ResponseEntity.ok(result);
     }
 
@@ -62,5 +60,19 @@ public class RushEventController {
     public ResponseEntity<Void> setTodayEvent() {
         rushEventService.setTodayEventToRedis();
         return ResponseEntity.noContent().build();
+    }
+
+    // 오늘의 이벤트 선택지 조회
+    @GetMapping("/today")
+    public ResponseEntity<MainRushEventOptionsResponseDto> getTodayEvent() {
+        MainRushEventOptionsResponseDto mainRushEventOptionsResponseDto = rushEventService.getTodayRushEventOptions();
+        return ResponseEntity.ok(mainRushEventOptionsResponseDto);
+    }
+
+    // 옵션 선택 결과 조회
+    @GetMapping("/options/{optionId}/result")
+    public ResponseEntity<ResultRushEventOptionResponseDto> getResultOption(@PathVariable("optionId") int optionId) {
+        ResultRushEventOptionResponseDto resultRushEventOptionResponseDto = rushEventService.getRushEventOptionResult(optionId);
+        return ResponseEntity.ok(resultRushEventOptionResponseDto);
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/RequestDto/CasperBotRequestDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/RequestDto/CasperBotRequestDto.java
@@ -3,7 +3,9 @@ package JGS.CasperEvent.domain.event.dto.RequestDto;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
 
+@Getter
 public class CasperBotRequestDto {
 
     @NotNull(message = "눈 모양 값은 필수 필드입니다.")
@@ -35,37 +37,5 @@ public class CasperBotRequestDto {
     private String name;
 
     private String expectation;
-
-
-    public Integer getEyeShape() {
-        return eyeShape;
-    }
-
-    public Integer getEyePosition() {
-        return eyePosition;
-    }
-
-    public Integer getMouthShape() {
-        return mouthShape;
-    }
-
-    public Integer getColor() {
-        return color;
-    }
-
-    public Integer getSticker() {
-        return sticker;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public String getExpectation() {
-        return expectation;
-    }
+    private String referralId;
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/RequestDto/LotteryEventRequestDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/RequestDto/LotteryEventRequestDto.java
@@ -9,10 +9,10 @@ import java.time.LocalDateTime;
 public class LotteryEventRequestDto {
 
     @NotNull(message = "이벤트 시작 일자를 지정하세요.")
-    private LocalDateTime eventStartDate;
+    private LocalDateTime eventStartDateTime;
 
     @NotNull(message = "이벤트 종료 일자를 지정하세요.")
-    private LocalDateTime eventEndDate;
+    private LocalDateTime eventEndDateTime;
 
     @NotNull(message = "당첨인원 수를 지정하세요.")
     private int winnerCount;

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/RequestDto/lotteryEventDto/CasperBotRequestDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/RequestDto/lotteryEventDto/CasperBotRequestDto.java
@@ -3,9 +3,13 @@ package JGS.CasperEvent.domain.event.dto.RequestDto.lotteryEventDto;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
+@Builder
+@EqualsAndHashCode
 public class CasperBotRequestDto {
 
     @NotNull(message = "눈 모양 값은 필수 필드입니다.")

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/RequestDto/lotteryEventDto/CasperBotRequestDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/RequestDto/lotteryEventDto/CasperBotRequestDto.java
@@ -1,4 +1,4 @@
-package JGS.CasperEvent.domain.event.dto.RequestDto;
+package JGS.CasperEvent.domain.event.dto.RequestDto.lotteryEventDto;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -37,5 +37,6 @@ public class CasperBotRequestDto {
     private String name;
 
     private String expectation;
-    private String referralId;
+
+    private String referralId = "";
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/RequestDto/lotteryEventDto/LotteryEventRequestDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/RequestDto/lotteryEventDto/LotteryEventRequestDto.java
@@ -3,16 +3,23 @@ package JGS.CasperEvent.domain.event.dto.RequestDto.lotteryEventDto;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
+import java.time.LocalTime;
 
 @Getter
 public class LotteryEventRequestDto {
 
-    @NotNull(message = "이벤트 시작 일자를 지정하세요.")
-    private LocalDateTime eventStartDateTime;
+    @NotNull(message = "이벤트 시작 날짜를 지정하세요.")
+    private LocalDate eventStartDate;
 
-    @NotNull(message = "이벤트 종료 일자를 지정하세요.")
-    private LocalDateTime eventEndDateTime;
+    @NotNull(message = "이벤트 시작 시간을 지정하세요.")
+    private LocalTime eventStartTime;
+
+    @NotNull(message = "이벤트 종료 날짜를 지정하세요.")
+    private LocalDate eventEndDate;
+
+    @NotNull(message = "이벤트 시작 시간을 지정하세요.")
+    private LocalTime eventEndTime;
 
     @NotNull(message = "당첨인원 수를 지정하세요.")
     private int winnerCount;

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/RequestDto/lotteryEventDto/LotteryEventRequestDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/RequestDto/lotteryEventDto/LotteryEventRequestDto.java
@@ -1,4 +1,4 @@
-package JGS.CasperEvent.domain.event.dto.RequestDto;
+package JGS.CasperEvent.domain.event.dto.RequestDto.lotteryEventDto;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/RequestDto/lotteryEventDto/LotteryEventRequestDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/RequestDto/lotteryEventDto/LotteryEventRequestDto.java
@@ -10,16 +10,16 @@ import java.time.LocalTime;
 public class LotteryEventRequestDto {
 
     @NotNull(message = "이벤트 시작 날짜를 지정하세요.")
-    private LocalDate eventStartDate;
+    private LocalDate startDate;
 
     @NotNull(message = "이벤트 시작 시간을 지정하세요.")
-    private LocalTime eventStartTime;
+    private LocalTime startTime;
 
     @NotNull(message = "이벤트 종료 날짜를 지정하세요.")
-    private LocalDate eventEndDate;
+    private LocalDate endDate;
 
     @NotNull(message = "이벤트 시작 시간을 지정하세요.")
-    private LocalTime eventEndTime;
+    private LocalTime endTime;
 
     @NotNull(message = "당첨인원 수를 지정하세요.")
     private int winnerCount;

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/RequestDto/rushEventDto/RushEventOptionRequestDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/RequestDto/rushEventDto/RushEventOptionRequestDto.java
@@ -1,11 +1,14 @@
 package JGS.CasperEvent.domain.event.dto.RequestDto.rushEventDto;
 
+import JGS.CasperEvent.global.enums.Position;
 import lombok.Getter;
 import lombok.ToString;
 
 @ToString
 @Getter
 public class RushEventOptionRequestDto {
+    private Long rushOptionId;
+    private Position position;
     private String mainText;
     private String subText;
     private String resultMainText;

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/RequestDto/rushEventDto/RushEventOptionRequestDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/RequestDto/rushEventDto/RushEventOptionRequestDto.java
@@ -1,0 +1,13 @@
+package JGS.CasperEvent.domain.event.dto.RequestDto.rushEventDto;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Getter
+public class RushEventOptionRequestDto {
+    private String mainText;
+    private String subText;
+    private String resultMainText;
+    private String resultSubText;
+}

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/RequestDto/rushEventDto/RushEventOptionRequestDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/RequestDto/rushEventDto/RushEventOptionRequestDto.java
@@ -13,4 +13,5 @@ public class RushEventOptionRequestDto {
     private String subText;
     private String resultMainText;
     private String resultSubText;
+    private String imageUrl;
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/RequestDto/rushEventDto/RushEventRequestDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/RequestDto/rushEventDto/RushEventRequestDto.java
@@ -3,6 +3,7 @@ package JGS.CasperEvent.domain.event.dto.RequestDto.rushEventDto;
 import JGS.CasperEvent.global.enums.CustomErrorCode;
 import JGS.CasperEvent.global.enums.Position;
 import JGS.CasperEvent.global.error.exception.CustomException;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -12,22 +13,38 @@ import java.util.Set;
 
 @ToString
 @Getter
+//todo 검증 항목 추가 필요
 public class RushEventRequestDto {
+    @NotNull(message = "선착순 이벤트 아이디는 필수 항목입니다.")
     private Long rushEventId;
+
+    @NotNull(message = "이벤트 시작 날짜는 필수 항목입니다.")
     private LocalDate eventDate;
+
+    @NotNull(message = "이벤트 시작 시간은 필수 항목입니다.")
     private LocalTime startTime;
+
+    @NotNull(message = "이벤트 종료 시간 필수 항목입니다.")
     private LocalTime endTime;
+
+    @NotNull(message = "당첨자 수는 필수 항목입니다.")
     private int winnerCount;
+
+    @NotNull(message = "상품 사진은 필수 항목입니다.")
+    private String prizeImageUrl;
+
+    @NotNull(message = "상품 상세 정보는 필수 항목입니다.")
     private String prizeDescription;
+
     private Set<RushEventOptionRequestDto> options;
 
-    public RushEventOptionRequestDto getLeftOption() {
+    public RushEventOptionRequestDto getLeftOptionRequestDto() {
         return options.stream()
                 .filter(option -> option.getPosition() == Position.LEFT)
                 .findFirst().orElseThrow(() -> new CustomException(CustomErrorCode.INVALID_RUSH_EVENT_OPTION));
     }
 
-    public RushEventOptionRequestDto getRightOption() {
+    public RushEventOptionRequestDto getRightOptionRequestDto() {
         return options.stream()
                 .filter(option -> option.getPosition() == Position.RIGHT)
                 .findFirst().orElseThrow(() -> new CustomException(CustomErrorCode.INVALID_RUSH_EVENT_OPTION));

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/RequestDto/rushEventDto/RushEventRequestDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/RequestDto/rushEventDto/RushEventRequestDto.java
@@ -1,0 +1,22 @@
+package JGS.CasperEvent.domain.event.dto.RequestDto.rushEventDto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@ToString
+@Getter
+public class RushEventRequestDto {
+    private LocalDate eventDate;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private int winnerCount;
+    private String prizeDescription;
+    @JsonProperty("leftOption")
+    private RushEventOptionRequestDto leftOption;
+    @JsonProperty("rightOption")
+    private RushEventOptionRequestDto rightOption;
+}

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/RequestDto/rushEventDto/RushEventRequestDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/RequestDto/rushEventDto/RushEventRequestDto.java
@@ -1,22 +1,35 @@
 package JGS.CasperEvent.domain.event.dto.RequestDto.rushEventDto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import JGS.CasperEvent.global.enums.CustomErrorCode;
+import JGS.CasperEvent.global.enums.Position;
+import JGS.CasperEvent.global.error.exception.CustomException;
 import lombok.Getter;
 import lombok.ToString;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Set;
 
 @ToString
 @Getter
 public class RushEventRequestDto {
+    private Long rushEventId;
     private LocalDate eventDate;
     private LocalTime startTime;
     private LocalTime endTime;
     private int winnerCount;
     private String prizeDescription;
-    @JsonProperty("leftOption")
-    private RushEventOptionRequestDto leftOption;
-    @JsonProperty("rightOption")
-    private RushEventOptionRequestDto rightOption;
+    private Set<RushEventOptionRequestDto> options;
+
+    public RushEventOptionRequestDto getLeftOption() {
+        return options.stream()
+                .filter(option -> option.getPosition() == Position.LEFT)
+                .findFirst().orElseThrow(() -> new CustomException(CustomErrorCode.INVALID_RUSH_EVENT_OPTION));
+    }
+
+    public RushEventOptionRequestDto getRightOption() {
+        return options.stream()
+                .filter(option -> option.getPosition() == Position.RIGHT)
+                .findFirst().orElseThrow(() -> new CustomException(CustomErrorCode.INVALID_RUSH_EVENT_OPTION));
+    }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/ImageUrlResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/ImageUrlResponseDto.java
@@ -1,0 +1,4 @@
+package JGS.CasperEvent.domain.event.dto.ResponseDto;
+
+public record ImageUrlResponseDto(String imageUrl) {
+}

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/LotteryEventDetailResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/LotteryEventDetailResponseDto.java
@@ -2,20 +2,27 @@ package JGS.CasperEvent.domain.event.dto.ResponseDto;
 
 import JGS.CasperEvent.domain.event.entity.event.LotteryEvent;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public record LotteryEventDetailResponseDto(LocalDateTime startDateTime, LocalDateTime endDateTime,
-                                            AtomicInteger appliedCount, int winnerCount,
-                                            LocalDateTime createdAt, LocalDateTime updatedAt) {
+public record LotteryEventDetailResponseDto(
+        LocalDate startDate, LocalTime startTime,
+        LocalDate endDate, LocalTime endTime,
+        AtomicInteger appliedCount, int winnerCount,
+        LocalDateTime createdAt, LocalDateTime updatedAt) {
+
     public static ArrayList<LotteryEventDetailResponseDto> of(List<LotteryEvent> lotteryEvent) {
         ArrayList<LotteryEventDetailResponseDto> lotteryEventDtoList = new ArrayList<>();
         for (LotteryEvent event : lotteryEvent) {
             lotteryEventDtoList.add(new LotteryEventDetailResponseDto(
-                    event.getStartDateTime(),
-                    event.getEndDateTime(),
+                    event.getStartDateTime().toLocalDate(),
+                    event.getStartDateTime().toLocalTime(),
+                    event.getEndDateTime().toLocalDate(),
+                    event.getEndDateTime().toLocalTime(),
                     event.getAppliedCount(),
                     event.getWinnerCount(),
                     event.getCreatedAt(),

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/LotteryEventDetailResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/LotteryEventDetailResponseDto.java
@@ -1,0 +1,26 @@
+package JGS.CasperEvent.domain.event.dto.ResponseDto;
+
+import JGS.CasperEvent.domain.event.entity.event.LotteryEvent;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public record LotteryEventDetailResponseDto(LocalDateTime startDateTime, LocalDateTime endDateTime,
+                                            AtomicInteger appliedCount, int winnerCount,
+                                            LocalDateTime createdAt, LocalDateTime updatedAt) {
+    public static ArrayList<LotteryEventDetailResponseDto> of(List<LotteryEvent> lotteryEvent) {
+        ArrayList<LotteryEventDetailResponseDto> lotteryEventDtoList = new ArrayList<>();
+        for (LotteryEvent event : lotteryEvent) {
+            lotteryEventDtoList.add(new LotteryEventDetailResponseDto(
+                    event.getStartDateTime(),
+                    event.getEndDateTime(),
+                    event.getAppliedCount(),
+                    event.getWinnerCount(),
+                    event.getCreatedAt(),
+                    event.getUpdatedAt()));
+        }
+        return lotteryEventDtoList;
+    }
+}

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/LotteryEventDetailResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/LotteryEventDetailResponseDto.java
@@ -23,7 +23,7 @@ public record LotteryEventDetailResponseDto(
                     event.getStartDateTime().toLocalTime(),
                     event.getEndDateTime().toLocalDate(),
                     event.getEndDateTime().toLocalTime(),
-                    event.getAppliedCount(),
+                    event.getTotalAppliedCount(),
                     event.getWinnerCount(),
                     event.getCreatedAt(),
                     event.getUpdatedAt()));

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/LotteryEventResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/LotteryEventResponseDto.java
@@ -5,7 +5,8 @@ import JGS.CasperEvent.domain.event.entity.event.LotteryEvent;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 
-public record LotteryEventResponseDto(LocalDateTime serverDateTime, LocalDateTime eventStartDate, LocalDateTime eventEndDate,
+public record LotteryEventResponseDto(LocalDateTime serverDateTime, LocalDateTime eventStartDate,
+                                      LocalDateTime eventEndDate,
                                       long activePeriod) {
     public static LotteryEventResponseDto of(LotteryEvent lotteryEvent, LocalDateTime serverDateTime) {
         return new LotteryEventResponseDto(
@@ -15,5 +16,4 @@ public record LotteryEventResponseDto(LocalDateTime serverDateTime, LocalDateTim
                 ChronoUnit.DAYS.between(lotteryEvent.getStartDateTime(), lotteryEvent.getEndDateTime())
         );
     }
-
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/MainRushEventOptionResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/MainRushEventOptionResponseDto.java
@@ -1,0 +1,12 @@
+package JGS.CasperEvent.domain.event.dto.ResponseDto;
+
+public record MainRushEventOptionResponseDto(String mainText,
+                                             String subText) {
+
+    public static MainRushEventOptionResponseDto of(RushEventOptionResponseDto rushEventOptionResponseDto) {
+        return new MainRushEventOptionResponseDto(
+                rushEventOptionResponseDto.mainText(),
+                rushEventOptionResponseDto.subText()
+        );
+    }
+}

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/MainRushEventOptionsResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/MainRushEventOptionsResponseDto.java
@@ -1,0 +1,11 @@
+package JGS.CasperEvent.domain.event.dto.ResponseDto;
+
+
+public record MainRushEventOptionsResponseDto(MainRushEventOptionResponseDto leftOption,
+                                              MainRushEventOptionResponseDto rightOption) {
+
+    public MainRushEventOptionsResponseDto(MainRushEventOptionResponseDto leftOption, MainRushEventOptionResponseDto rightOption) {
+        this.leftOption = leftOption;
+        this.rightOption = rightOption;
+    }
+}

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/ResultRushEventOptionResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/ResultRushEventOptionResponseDto.java
@@ -1,0 +1,11 @@
+package JGS.CasperEvent.domain.event.dto.ResponseDto;
+
+public record ResultRushEventOptionResponseDto(String mainText, String resultMainText, String resultSubText) {
+    public static ResultRushEventOptionResponseDto of(RushEventOptionResponseDto rushEventOptionResponseDto) {
+        return new ResultRushEventOptionResponseDto(
+                rushEventOptionResponseDto.mainText(),
+                rushEventOptionResponseDto.resultMainText(),
+                rushEventOptionResponseDto.resultSubText()
+        );
+    }
+}

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/RushEventOptionResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/RushEventOptionResponseDto.java
@@ -1,0 +1,17 @@
+package JGS.CasperEvent.domain.event.dto.ResponseDto;
+
+import JGS.CasperEvent.domain.event.entity.event.RushOption;
+import JGS.CasperEvent.global.enums.Position;
+
+public record RushEventOptionResponseDto(String mainText, String subText, String resultMainText, String resultSubText, String imageUrl, Position position) {
+    public static RushEventOptionResponseDto of(RushOption rushOption) {
+        return new RushEventOptionResponseDto(
+                rushOption.getMainText(),
+                rushOption.getSubText(),
+                rushOption.getResultMainText(),
+                rushOption.getResultSubText(),
+                rushOption.getImageUrl(),
+                rushOption.getPosition()
+        );
+    }
+}

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/RushEventRateResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/RushEventRateResponseDto.java
@@ -1,7 +1,4 @@
 package JGS.CasperEvent.domain.event.dto.ResponseDto;
 
-import lombok.Getter;
-
-@Getter
-public record RushEventRateResponseDto(long leftOption, long rightOption) {
+public record RushEventRateResponseDto(int optionId, long leftOption, long rightOption) {
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/RushEventResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/RushEventResponseDto.java
@@ -2,16 +2,34 @@ package JGS.CasperEvent.domain.event.dto.ResponseDto;
 
 import JGS.CasperEvent.domain.event.entity.event.RushEvent;
 import JGS.CasperEvent.domain.event.entity.event.RushOption;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Set;
+import java.util.stream.Collectors;
 
-public record RushEventResponseDto(Long rushEventId, LocalDateTime startDateTime, LocalDateTime endDateTime,
-                                   int winnerCount, String prizeImageUrl, String prizeDescription,
-                                   Set<RushOption> options){
+public record RushEventResponseDto(Long rushEventId,
+                                   @JsonSerialize(using = LocalDateTimeSerializer.class)
+                                   @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+
+                                   LocalDateTime startDateTime,
+                                   @JsonSerialize(using = LocalDateTimeSerializer.class)
+                                   @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+
+                                   LocalDateTime endDateTime,
+                                   int winnerCount, String prizeImageUrl,
+                                   String prizeDescription,
+                                   Set<RushEventOptionResponseDto> options){
 
     public static RushEventResponseDto of (RushEvent rushEvent){
+        Set<RushEventOptionResponseDto> options = rushEvent.getOptions().stream()
+                .map(RushEventOptionResponseDto::of)
+                .collect(Collectors.toSet());
+
         return new RushEventResponseDto(
                 rushEvent.getRushEventId(),
                 rushEvent.getStartDateTime(),
@@ -19,8 +37,7 @@ public record RushEventResponseDto(Long rushEventId, LocalDateTime startDateTime
                 rushEvent.getWinnerCount(),
                 rushEvent.getPrizeImageUrl(),
                 rushEvent.getPrizeDescription(),
-                rushEvent.getOptions()
+                options
         );
     }
-
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/TotalEventDateResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/TotalEventDateResponseDto.java
@@ -1,0 +1,6 @@
+package JGS.CasperEvent.domain.event.dto.ResponseDto;
+
+import java.time.LocalDate;
+
+public record TotalEventDateResponseDto(LocalDate totalEventStartDate, LocalDate totalEventEndDate) {
+}

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/lotteryEventResponseDto/CasperBotResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/lotteryEventResponseDto/CasperBotResponseDto.java
@@ -1,4 +1,4 @@
-package JGS.CasperEvent.domain.event.dto.ResponseDto;
+package JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto;
 
 import JGS.CasperEvent.domain.event.entity.casperBot.CasperBot;
 import org.springframework.data.annotation.Id;

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/lotteryEventResponseDto/LotteryEventDetailResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/lotteryEventResponseDto/LotteryEventDetailResponseDto.java
@@ -1,4 +1,4 @@
-package JGS.CasperEvent.domain.event.dto.ResponseDto;
+package JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto;
 
 import JGS.CasperEvent.domain.event.entity.event.LotteryEvent;
 

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/lotteryEventResponseDto/LotteryEventDetailResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/lotteryEventResponseDto/LotteryEventDetailResponseDto.java
@@ -7,12 +7,11 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public record LotteryEventDetailResponseDto(
         LocalDate startDate, LocalTime startTime,
         LocalDate endDate, LocalTime endTime,
-        AtomicInteger appliedCount, int winnerCount,
+        int appliedCount, int winnerCount,
         LocalDateTime createdAt, LocalDateTime updatedAt) {
 
     public static ArrayList<LotteryEventDetailResponseDto> of(List<LotteryEvent> lotteryEvent) {

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/lotteryEventResponseDto/LotteryEventDetailResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/lotteryEventResponseDto/LotteryEventDetailResponseDto.java
@@ -1,32 +1,37 @@
 package JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto;
 
 import JGS.CasperEvent.domain.event.entity.event.LotteryEvent;
+import JGS.CasperEvent.global.enums.EventStatus;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.List;
 
 public record LotteryEventDetailResponseDto(
         LocalDate startDate, LocalTime startTime,
         LocalDate endDate, LocalTime endTime,
         int appliedCount, int winnerCount,
+        EventStatus status,
         LocalDateTime createdAt, LocalDateTime updatedAt) {
 
-    public static ArrayList<LotteryEventDetailResponseDto> of(List<LotteryEvent> lotteryEvent) {
-        ArrayList<LotteryEventDetailResponseDto> lotteryEventDtoList = new ArrayList<>();
-        for (LotteryEvent event : lotteryEvent) {
-            lotteryEventDtoList.add(new LotteryEventDetailResponseDto(
-                    event.getStartDateTime().toLocalDate(),
-                    event.getStartDateTime().toLocalTime(),
-                    event.getEndDateTime().toLocalDate(),
-                    event.getEndDateTime().toLocalTime(),
-                    event.getTotalAppliedCount(),
-                    event.getWinnerCount(),
-                    event.getCreatedAt(),
-                    event.getUpdatedAt()));
-        }
-        return lotteryEventDtoList;
+    public static LotteryEventDetailResponseDto of(LotteryEvent event) {
+
+        EventStatus status;
+        LocalDateTime now = LocalDateTime.now();
+
+        if (now.isBefore(event.getStartDateTime())) status = EventStatus.BEFORE;
+        else if (now.isAfter(event.getEndDateTime())) status = EventStatus.AFTER;
+        else status = EventStatus.DURING;
+
+        return new LotteryEventDetailResponseDto(
+                event.getStartDateTime().toLocalDate(),
+                event.getStartDateTime().toLocalTime(),
+                event.getEndDateTime().toLocalDate(),
+                event.getEndDateTime().toLocalTime(),
+                event.getTotalAppliedCount(),
+                event.getWinnerCount(),
+                status,
+                event.getCreatedAt(),
+                event.getUpdatedAt());
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/lotteryEventResponseDto/LotteryEventExpectationResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/lotteryEventResponseDto/LotteryEventExpectationResponseDto.java
@@ -1,0 +1,24 @@
+package JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto;
+
+import JGS.CasperEvent.domain.event.entity.casperBot.CasperBot;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public record LotteryEventExpectationResponseDto(String expectation, LocalDate createdDate,
+                                                 LocalTime createdTime) {
+
+    public static LotteryEventExpectationResponseDto of(CasperBot casperBot) {
+
+        LocalDateTime createdAt = casperBot.getCreatedAt();
+        LocalDate createdDate = createdAt.toLocalDate();
+        LocalTime createdTime = createdAt.toLocalTime();
+
+        return new LotteryEventExpectationResponseDto(
+                casperBot.getExpectation(),
+                createdDate,
+                createdTime
+        );
+    }
+}

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/lotteryEventResponseDto/LotteryEventExpectationResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/lotteryEventResponseDto/LotteryEventExpectationResponseDto.java
@@ -6,7 +6,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 
-public record LotteryEventExpectationResponseDto(String expectation, LocalDate createdDate,
+public record LotteryEventExpectationResponseDto(Long casperId, String expectation, LocalDate createdDate,
                                                  LocalTime createdTime) {
 
     public static LotteryEventExpectationResponseDto of(CasperBot casperBot) {
@@ -16,6 +16,7 @@ public record LotteryEventExpectationResponseDto(String expectation, LocalDate c
         LocalTime createdTime = createdAt.toLocalTime();
 
         return new LotteryEventExpectationResponseDto(
+                casperBot.getCasperId(),
                 casperBot.getExpectation(),
                 createdDate,
                 createdTime

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/lotteryEventResponseDto/LotteryEventExpectationsResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/lotteryEventResponseDto/LotteryEventExpectationsResponseDto.java
@@ -1,0 +1,7 @@
+package JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto;
+
+import java.util.List;
+
+public record LotteryEventExpectationsResponseDto(List<LotteryEventExpectationResponseDto> expectations,
+                                                  Boolean isLastPage, long totalExpectations) {
+}

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/lotteryEventResponseDto/LotteryEventParticipantsListResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/lotteryEventResponseDto/LotteryEventParticipantsListResponseDto.java
@@ -1,0 +1,6 @@
+package JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto;
+
+import java.util.List;
+
+public record LotteryEventParticipantsListResponseDto(List<LotteryEventParticipantsResponseDto> participantsList, Boolean isLastPage, long totalParticipants) {
+}

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/lotteryEventResponseDto/LotteryEventParticipantsResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/lotteryEventResponseDto/LotteryEventParticipantsResponseDto.java
@@ -3,7 +3,6 @@ package JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto;
 import JGS.CasperEvent.domain.event.entity.participants.LotteryParticipants;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 public record LotteryEventParticipantsResponseDto(

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/lotteryEventResponseDto/LotteryEventParticipantsResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/lotteryEventResponseDto/LotteryEventParticipantsResponseDto.java
@@ -2,12 +2,14 @@ package JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto;
 
 import JGS.CasperEvent.domain.event.entity.participants.LotteryParticipants;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 public record LotteryEventParticipantsResponseDto(
         Long id, String phoneNumber, int linkClickedCounts,
         int expectation, int appliedCount,
-        LocalDateTime createdAt, LocalDateTime updatedAt) {
+        LocalDate createdDate, LocalTime createdTime) {
 
     public static LotteryEventParticipantsResponseDto of(LotteryParticipants participant) {
         return new LotteryEventParticipantsResponseDto(
@@ -16,8 +18,9 @@ public record LotteryEventParticipantsResponseDto(
                 participant.getLinkClickedCount(),
                 participant.getExpectations(),
                 participant.getAppliedCount(),
-                participant.getBaseUser().getCreatedAt(),
-                participant.getBaseUser().getUpdatedAt()
+                participant.getBaseUser().getCreatedAt().toLocalDate(),
+                participant.getBaseUser().getCreatedAt().toLocalTime()
         );
     }
+
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/lotteryEventResponseDto/LotteryEventParticipantsResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/lotteryEventResponseDto/LotteryEventParticipantsResponseDto.java
@@ -1,0 +1,23 @@
+package JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto;
+
+import JGS.CasperEvent.domain.event.entity.participants.LotteryParticipants;
+
+import java.time.LocalDateTime;
+
+public record LotteryEventParticipantsResponseDto(
+        Long id, String phoneNumber, int linkClickedCounts,
+        int expectation, int appliedCount,
+        LocalDateTime createdAt, LocalDateTime updatedAt) {
+
+    public static LotteryEventParticipantsResponseDto of(LotteryParticipants participant) {
+        return new LotteryEventParticipantsResponseDto(
+                participant.getId(),
+                participant.getBaseUser().getId(),
+                participant.getLinkClickedCount(),
+                participant.getExpectations(),
+                participant.getAppliedCount(),
+                participant.getBaseUser().getCreatedAt(),
+                participant.getBaseUser().getUpdatedAt()
+        );
+    }
+}

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/lotteryEventResponseDto/LotteryEventResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/lotteryEventResponseDto/LotteryEventResponseDto.java
@@ -1,4 +1,4 @@
-package JGS.CasperEvent.domain.event.dto.ResponseDto;
+package JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto;
 
 import JGS.CasperEvent.domain.event.entity.event.LotteryEvent;
 

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/lotteryEventResponseDto/LotteryParticipantResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/lotteryEventResponseDto/LotteryParticipantResponseDto.java
@@ -1,4 +1,4 @@
-package JGS.CasperEvent.domain.event.dto.ResponseDto;
+package JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto;
 import JGS.CasperEvent.domain.event.entity.participants.LotteryParticipants;
 
 import java.time.LocalDateTime;

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/AdminRushEventOptionResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/AdminRushEventOptionResponseDto.java
@@ -1,0 +1,15 @@
+package JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto;
+
+import JGS.CasperEvent.domain.event.entity.event.RushEvent;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public record AdminRushEventOptionResponseDto(Set<RushEventOptionResponseDto> options) {
+    public static AdminRushEventOptionResponseDto of(RushEvent rushEvent){
+        Set<RushEventOptionResponseDto> optionResponseDtoList = new HashSet<>();
+        optionResponseDtoList.add(RushEventOptionResponseDto.of(rushEvent.getLeftOption()));
+        optionResponseDtoList.add(RushEventOptionResponseDto.of(rushEvent.getRightOption()));
+        return new AdminRushEventOptionResponseDto(optionResponseDtoList);
+    }
+}

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/AdminRushEventResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/AdminRushEventResponseDto.java
@@ -6,8 +6,6 @@ import JGS.CasperEvent.global.enums.EventStatus;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -16,35 +14,29 @@ public record AdminRushEventResponseDto(Long rushEventId, LocalDate eventDate,
                                         int winnerCount, String prizeImageUrl,
                                         String prizeDescription, LocalDateTime createdAt, LocalDateTime updatedAt,
                                         EventStatus status, Set<RushEventOptionResponseDto> options) {
+    public static AdminRushEventResponseDto of(RushEvent rushEvent){
+        Set<RushEventOptionResponseDto> options = rushEvent.getOptions().stream()
+                .map(RushEventOptionResponseDto::of)
+                .collect(Collectors.toSet());
 
-    public static List<AdminRushEventResponseDto> of(List<RushEvent> rushEvents) {
-        List<AdminRushEventResponseDto> dtoList = new ArrayList<>();
-        for (RushEvent rushEvent : rushEvents) {
-            Set<RushEventOptionResponseDto> options = rushEvent.getOptions().stream()
-                    .map(RushEventOptionResponseDto::of)
-                    .collect(Collectors.toSet());
+        LocalDateTime now = LocalDateTime.now();
+        EventStatus status;
+        if (now.isBefore(rushEvent.getStartDateTime())) status = EventStatus.BEFORE;
+        else if (now.isAfter(rushEvent.getEndDateTime())) status = EventStatus.AFTER;
+        else status = EventStatus.DURING;
 
-            LocalDateTime now = LocalDateTime.now();
-            EventStatus status;
-            if (now.isBefore(rushEvent.getStartDateTime())) status = EventStatus.BEFORE;
-            else if (now.isAfter(rushEvent.getEndDateTime())) status = EventStatus.AFTER;
-            else status = EventStatus.DURING;
-
-            dtoList.add(new AdminRushEventResponseDto(
-                    rushEvent.getRushEventId(),
-                    rushEvent.getStartDateTime().toLocalDate(),
-                    rushEvent.getStartDateTime().toLocalTime(),
-                    rushEvent.getEndDateTime().toLocalTime(),
-                    rushEvent.getWinnerCount(),
-                    rushEvent.getPrizeImageUrl(),
-                    rushEvent.getPrizeDescription(),
-                    rushEvent.getCreatedAt(),
-                    rushEvent.getUpdatedAt(),
-                    status,
-                    options
-            ));
-        }
-
-        return dtoList;
+        return new AdminRushEventResponseDto(
+                rushEvent.getRushEventId(),
+                rushEvent.getStartDateTime().toLocalDate(),
+                rushEvent.getStartDateTime().toLocalTime(),
+                rushEvent.getEndDateTime().toLocalTime(),
+                rushEvent.getWinnerCount(),
+                rushEvent.getPrizeImageUrl(),
+                rushEvent.getPrizeDescription(),
+                rushEvent.getCreatedAt(),
+                rushEvent.getUpdatedAt(),
+                status,
+                options
+        );
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/AdminRushEventResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/AdminRushEventResponseDto.java
@@ -1,0 +1,50 @@
+package JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto;
+
+import JGS.CasperEvent.domain.event.entity.event.RushEvent;
+import JGS.CasperEvent.global.enums.EventStatus;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public record AdminRushEventResponseDto(Long rushEventId, LocalDate eventDate,
+                                        LocalTime startTime, LocalTime endTime,
+                                        int winnerCount, String prizeImageUrl,
+                                        String prizeDescription, LocalDateTime createdAt, LocalDateTime updatedAt,
+                                        EventStatus status, Set<RushEventOptionResponseDto> options) {
+
+    public static List<AdminRushEventResponseDto> of(List<RushEvent> rushEvents) {
+        List<AdminRushEventResponseDto> dtoList = new ArrayList<>();
+        for (RushEvent rushEvent : rushEvents) {
+            Set<RushEventOptionResponseDto> options = rushEvent.getOptions().stream()
+                    .map(RushEventOptionResponseDto::of)
+                    .collect(Collectors.toSet());
+
+            LocalDateTime now = LocalDateTime.now();
+            EventStatus status;
+            if (now.isBefore(rushEvent.getStartDateTime())) status = EventStatus.BEFORE;
+            else if (now.isAfter(rushEvent.getEndDateTime())) status = EventStatus.AFTER;
+            else status = EventStatus.DURING;
+
+            dtoList.add(new AdminRushEventResponseDto(
+                    rushEvent.getRushEventId(),
+                    rushEvent.getStartDateTime().toLocalDate(),
+                    rushEvent.getStartDateTime().toLocalTime(),
+                    rushEvent.getEndDateTime().toLocalTime(),
+                    rushEvent.getWinnerCount(),
+                    rushEvent.getPrizeImageUrl(),
+                    rushEvent.getPrizeDescription(),
+                    rushEvent.getCreatedAt(),
+                    rushEvent.getUpdatedAt(),
+                    status,
+                    options
+            ));
+        }
+
+        return dtoList;
+    }
+}

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/LotteryEventWinnerListResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/LotteryEventWinnerListResponseDto.java
@@ -1,0 +1,7 @@
+package JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto;
+
+import java.util.List;
+
+public record LotteryEventWinnerListResponseDto(List<LotteryEventWinnerResponseDto> participantsList,
+                                                Boolean isLastPage, long totalParticipants) {
+}

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/LotteryEventWinnerResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/LotteryEventWinnerResponseDto.java
@@ -1,0 +1,25 @@
+package JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto;
+
+import JGS.CasperEvent.domain.event.entity.participants.LotteryWinners;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record LotteryEventWinnerResponseDto(
+        Long id, String phoneNumber, int linkClickedCounts,
+        int expectation, int appliedCount, long ranking,
+        LocalDate createdDate, LocalTime createdTime) {
+
+    public static LotteryEventWinnerResponseDto of(LotteryWinners lotteryWinner) {
+        return new LotteryEventWinnerResponseDto(
+                lotteryWinner.getId(),
+                lotteryWinner.getPhoneNumber(),
+                lotteryWinner.getLinkClickedCount(),
+                lotteryWinner.getExpectation(),
+                lotteryWinner.getAppliedCount(),
+                lotteryWinner.getRanking(),
+                lotteryWinner.getCreatedAt().toLocalDate(),
+                lotteryWinner.getCreatedAt().toLocalTime()
+        );
+    }
+}

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/MainRushEventOptionResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/MainRushEventOptionResponseDto.java
@@ -1,4 +1,4 @@
-package JGS.CasperEvent.domain.event.dto.ResponseDto;
+package JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto;
 
 public record MainRushEventOptionResponseDto(String mainText,
                                              String subText) {

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/MainRushEventOptionsResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/MainRushEventOptionsResponseDto.java
@@ -1,4 +1,4 @@
-package JGS.CasperEvent.domain.event.dto.ResponseDto;
+package JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto;
 
 
 public record MainRushEventOptionsResponseDto(MainRushEventOptionResponseDto leftOption,

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/MainRushEventResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/MainRushEventResponseDto.java
@@ -1,4 +1,4 @@
-package JGS.CasperEvent.domain.event.dto.ResponseDto;
+package JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto;
 
 import JGS.CasperEvent.domain.event.entity.event.RushEvent;
 import lombok.Getter;

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/ResultRushEventOptionResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/ResultRushEventOptionResponseDto.java
@@ -1,4 +1,4 @@
-package JGS.CasperEvent.domain.event.dto.ResponseDto;
+package JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto;
 
 public record ResultRushEventOptionResponseDto(String mainText, String resultMainText, String resultSubText) {
     public static ResultRushEventOptionResponseDto of(RushEventOptionResponseDto rushEventOptionResponseDto) {

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventListResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventListResponseDto.java
@@ -1,4 +1,4 @@
-package JGS.CasperEvent.domain.event.dto.ResponseDto;
+package JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto;
 
 import lombok.Getter;
 

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventOptionResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventOptionResponseDto.java
@@ -1,4 +1,4 @@
-package JGS.CasperEvent.domain.event.dto.ResponseDto;
+package JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto;
 
 import JGS.CasperEvent.domain.event.entity.event.RushOption;
 import JGS.CasperEvent.global.enums.Position;

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventOptionResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventOptionResponseDto.java
@@ -2,13 +2,23 @@ package JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto;
 
 import JGS.CasperEvent.domain.event.entity.event.RushOption;
 import JGS.CasperEvent.global.enums.Position;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 
 import java.time.LocalDateTime;
 
 public record RushEventOptionResponseDto(long optionId, String mainText,
                                          String subText, String resultMainText,
                                          String resultSubText, String imageUrl,
-                                         Position position, LocalDateTime createdAt, LocalDateTime updatedAt) {
+                                         Position position,
+                                         @JsonSerialize(using = LocalDateTimeSerializer.class)
+                                         @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+                                         LocalDateTime createdAt,
+                                         @JsonSerialize(using = LocalDateTimeSerializer.class)
+                                         @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+                                         LocalDateTime updatedAt) {
     public static RushEventOptionResponseDto of(RushOption rushOption) {
         return new RushEventOptionResponseDto(
                 rushOption.getOptionId(),

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventOptionResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventOptionResponseDto.java
@@ -3,15 +3,24 @@ package JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto;
 import JGS.CasperEvent.domain.event.entity.event.RushOption;
 import JGS.CasperEvent.global.enums.Position;
 
-public record RushEventOptionResponseDto(String mainText, String subText, String resultMainText, String resultSubText, String imageUrl, Position position) {
+import java.time.LocalDateTime;
+
+public record RushEventOptionResponseDto(long optionId, String mainText,
+                                         String subText, String resultMainText,
+                                         String resultSubText, String imageUrl,
+                                         Position position, LocalDateTime createdAt, LocalDateTime updatedAt) {
     public static RushEventOptionResponseDto of(RushOption rushOption) {
         return new RushEventOptionResponseDto(
+                rushOption.getOptionId(),
                 rushOption.getMainText(),
                 rushOption.getSubText(),
                 rushOption.getResultMainText(),
                 rushOption.getResultSubText(),
                 rushOption.getImageUrl(),
-                rushOption.getPosition()
+                rushOption.getPosition(),
+                rushOption.getCreatedAt(),
+                rushOption.getUpdatedAt()
         );
     }
+
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventParticipantResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventParticipantResponseDto.java
@@ -1,0 +1,20 @@
+package JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto;
+
+import JGS.CasperEvent.domain.event.entity.participants.RushParticipants;
+
+import java.time.LocalDateTime;
+
+public record RushEventParticipantResponseDto(Long id, String phoneNumber,
+                                              int balanceGameChoice, LocalDateTime createdAt, LocalDateTime updatedAt,
+                                              Long rank) {
+    public static RushEventParticipantResponseDto of(RushParticipants rushParticipants, Long rank){
+        return new RushEventParticipantResponseDto(
+                rushParticipants.getId(),
+                rushParticipants.getBaseUser().getId(),
+                rushParticipants.getOptionId(),
+                rushParticipants.getCreatedAt(),
+                rushParticipants.getUpdatedAt(),
+                rank
+        );
+    }
+}

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventParticipantResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventParticipantResponseDto.java
@@ -3,7 +3,6 @@ package JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto;
 import JGS.CasperEvent.domain.event.entity.participants.RushParticipants;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 public record RushEventParticipantResponseDto(Long id, String phoneNumber,

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventParticipantResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventParticipantResponseDto.java
@@ -2,18 +2,20 @@ package JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto;
 
 import JGS.CasperEvent.domain.event.entity.participants.RushParticipants;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 
 public record RushEventParticipantResponseDto(Long id, String phoneNumber,
-                                              int balanceGameChoice, LocalDateTime createdAt, LocalDateTime updatedAt,
+                                              int balanceGameChoice, LocalDate createdDate, LocalTime createdTime,
                                               Long rank) {
     public static RushEventParticipantResponseDto of(RushParticipants rushParticipants, Long rank){
         return new RushEventParticipantResponseDto(
                 rushParticipants.getId(),
                 rushParticipants.getBaseUser().getId(),
                 rushParticipants.getOptionId(),
-                rushParticipants.getCreatedAt(),
-                rushParticipants.getUpdatedAt(),
+                rushParticipants.getCreatedAt().toLocalDate(),
+                rushParticipants.getCreatedAt().toLocalTime(),
                 rank
         );
     }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventParticipantsListResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventParticipantsListResponseDto.java
@@ -1,4 +1,5 @@
 package JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto;
 
-public class RushEventParticipantsListResponseDto {
+import java.util.List;
+public record RushEventParticipantsListResponseDto(List<RushEventParticipantResponseDto> participantsList, Boolean isLastPage, long totalParticipants) {
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventParticipantsListResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventParticipantsListResponseDto.java
@@ -1,0 +1,4 @@
+package JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto;
+
+public class RushEventParticipantsListResponseDto {
+}

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventRateResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventRateResponseDto.java
@@ -1,4 +1,4 @@
-package JGS.CasperEvent.domain.event.dto.ResponseDto;
+package JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto;
 
 public record RushEventRateResponseDto(int optionId, long leftOption, long rightOption) {
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventResponseDto.java
@@ -1,13 +1,11 @@
-package JGS.CasperEvent.domain.event.dto.ResponseDto;
+package JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto;
 
 import JGS.CasperEvent.domain.event.entity.event.RushEvent;
-import JGS.CasperEvent.domain.event.entity.event.RushOption;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventResponseDto.java
@@ -13,12 +13,12 @@ import java.util.stream.Collectors;
 public record RushEventResponseDto(Long rushEventId,
                                    @JsonSerialize(using = LocalDateTimeSerializer.class)
                                    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
-
                                    LocalDateTime startDateTime,
+
                                    @JsonSerialize(using = LocalDateTimeSerializer.class)
                                    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
-
                                    LocalDateTime endDateTime,
+
                                    int winnerCount, String prizeImageUrl,
                                    String prizeDescription,
                                    Set<RushEventOptionResponseDto> options){

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventResultResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventResultResponseDto.java
@@ -1,4 +1,4 @@
-package JGS.CasperEvent.domain.event.dto.ResponseDto;
+package JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventResultResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventResultResponseDto.java
@@ -10,13 +10,13 @@ public class RushEventResultResponseDto {
     private final long rightOption;
     private final long rank;
     private final long totalParticipants;
-    private final long winnerCount;
+    private final boolean isWinner;
 
-    public RushEventResultResponseDto(RushEventRateResponseDto rushEventRateResponseDto, long rank, long totalParticipants, long winnerCount) {
+    public RushEventResultResponseDto(RushEventRateResponseDto rushEventRateResponseDto, long rank, long totalParticipants, boolean isWinner) {
         this.leftOption = rushEventRateResponseDto.leftOption();
         this.rightOption = rushEventRateResponseDto.rightOption();
         this.rank = rank;
         this.totalParticipants = totalParticipants;
-        this.winnerCount = winnerCount;
+        this.isWinner = isWinner;
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/entity/casperBot/CasperBot.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/entity/casperBot/CasperBot.java
@@ -40,4 +40,16 @@ public class CasperBot extends BaseEntity {
         this.name = requestDto.getName();
         this.expectation = requestDto.getExpectation();
     }
+
+    public CasperBot deleteExpectation() {
+        if (!this.expectation.isEmpty()) {
+            this.expectation = "삭제된 기대평입니다.";
+        }
+
+        return this;
+    }
+
+    public boolean isDeleted() {
+        return this.expectation.equals("삭제된 기대평입니다.");
+    }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/entity/casperBot/CasperBot.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/entity/casperBot/CasperBot.java
@@ -2,26 +2,20 @@ package JGS.CasperEvent.domain.event.entity.casperBot;
 
 import JGS.CasperEvent.domain.event.dto.RequestDto.CasperBotRequestDto;
 import JGS.CasperEvent.global.entity.BaseEntity;
-import JGS.CasperEvent.global.util.UserUtil;
 import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.ToString;
 
 
 @Entity
+@Getter
+@ToString
 public class CasperBot extends BaseEntity {
-    public CasperBot(CasperBotRequestDto postCasperBot, String phoneNumber) {
-        this.casperId = UserUtil.generateId();
-        this.phoneNumber = phoneNumber;
-        this.eyeShape = postCasperBot.getEyeShape();
-        this.eyePosition = postCasperBot.getEyePosition();
-        this.mouthShape = postCasperBot.getMouthShape();
-        this.color = postCasperBot.getColor();
-        this.sticker = postCasperBot.getSticker();
-        this.name = postCasperBot.getName();
-        this.expectation = postCasperBot.getExpectation();
-    }
 
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long casperId;
+
     private String phoneNumber;
 
     private int eyeShape;
@@ -36,56 +30,14 @@ public class CasperBot extends BaseEntity {
 
     }
 
-    public Long getCasperId() {
-        return casperId;
-    }
-
-    public String getPhoneNumber() {
-        return phoneNumber;
-    }
-
-    public int getEyeShape() {
-        return eyeShape;
-    }
-
-    public int getEyePosition() {
-        return eyePosition;
-    }
-
-    public int getMouthShape() {
-        return mouthShape;
-    }
-
-    public int getColor() {
-        return color;
-    }
-
-    public int getSticker() {
-        return sticker;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public String getExpectation() {
-        return expectation;
-    }
-
-    @Override
-    public String toString() {
-        return "CasperBot{" +
-                "casperId=" + casperId +
-                ", phoneNumber='" + phoneNumber + '\'' +
-                ", eyeShape=" + eyeShape +
-                ", eyePosition=" + eyePosition +
-                ", mouthShape=" + mouthShape +
-                ", color=" + color +
-                ", sticker=" + sticker +
-                ", name='" + name + '\'' +
-                ", expectation='" + expectation + '\'' +
-                ", createdAt='" + getCreatedAt() + '\'' +
-                ", updatedAt='" + getUpdatedAt() + '\'' +
-                '}';
+    public CasperBot(CasperBotRequestDto requestDto, String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+        this.eyeShape = requestDto.getEyeShape();
+        this.eyePosition = requestDto.getEyePosition();
+        this.mouthShape = requestDto.getMouthShape();
+        this.color = requestDto.getColor();
+        this.sticker = requestDto.getSticker();
+        this.name = requestDto.getName();
+        this.expectation = requestDto.getExpectation();
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/entity/casperBot/CasperBot.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/entity/casperBot/CasperBot.java
@@ -1,6 +1,6 @@
 package JGS.CasperEvent.domain.event.entity.casperBot;
 
-import JGS.CasperEvent.domain.event.dto.RequestDto.CasperBotRequestDto;
+import JGS.CasperEvent.domain.event.dto.RequestDto.lotteryEventDto.CasperBotRequestDto;
 import JGS.CasperEvent.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Getter;

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/entity/casperBot/CasperBot.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/entity/casperBot/CasperBot.java
@@ -25,6 +25,7 @@ public class CasperBot extends BaseEntity {
     private int sticker;
     private String name;
     private String expectation;
+    private boolean isDeleted;
 
     public CasperBot() {
 
@@ -41,15 +42,7 @@ public class CasperBot extends BaseEntity {
         this.expectation = requestDto.getExpectation();
     }
 
-    public CasperBot deleteExpectation() {
-        if (!this.expectation.isEmpty()) {
-            this.expectation = "삭제된 기대평입니다.";
-        }
-
-        return this;
-    }
-
-    public boolean isDeleted() {
-        return this.expectation.equals("삭제된 기대평입니다.");
+    public void deleteExpectation() {
+        this.isDeleted = true;
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/BaseEvent.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/BaseEvent.java
@@ -7,10 +7,12 @@ import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 
 @Getter
+@Setter
 @MappedSuperclass
 public class BaseEvent extends BaseEntity {
     @JsonSerialize(using = LocalDateTimeSerializer.class)

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/BaseEvent.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/BaseEvent.java
@@ -15,12 +15,12 @@ import java.time.LocalDateTime;
 public class BaseEvent extends BaseEntity {
     @JsonSerialize(using = LocalDateTimeSerializer.class)
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
-    private LocalDateTime startDateTime;
+    protected LocalDateTime startDateTime;
 
     @JsonSerialize(using = LocalDateTimeSerializer.class)
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
-    private LocalDateTime endDateTime;
-    private int winnerCount;
+    protected LocalDateTime endDateTime;
+    protected int winnerCount;
 
     // 기본 생성자에서 디폴트 값 설정
     public BaseEvent() {

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/BaseEvent.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/BaseEvent.java
@@ -9,7 +9,6 @@ import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
-import java.util.concurrent.atomic.AtomicInteger;
 
 @Getter
 @MappedSuperclass
@@ -22,14 +21,14 @@ public class BaseEvent extends BaseEntity {
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     protected LocalDateTime endDateTime;
     protected int winnerCount;
-    protected AtomicInteger totalAppliedCount;
+    protected int totalAppliedCount;
 
     // 기본 생성자에서 디폴트 값 설정
     public BaseEvent() {
         this.startDateTime = LocalDateTime.now();
         this.endDateTime = LocalDateTime.now().plusMinutes(10);
         this.winnerCount = 0; // 기본 우승자 수를 0으로 설정
-        this.totalAppliedCount = new AtomicInteger(0);
+        this.totalAppliedCount = 0;
     }
 
     // 특정 값을 설정할 수 있는 생성자
@@ -37,10 +36,10 @@ public class BaseEvent extends BaseEntity {
         this.startDateTime = startDateTime;
         this.endDateTime = endDateTime;
         this.winnerCount = winnerCount;
-        this.totalAppliedCount = new AtomicInteger(0);
+        this.totalAppliedCount = 0;
     }
 
-    public void addAppliedCount(){
-        this.totalAppliedCount.addAndGet(1);
+    public void addAppliedCount() {
+        this.totalAppliedCount++;
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/BaseEvent.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/BaseEvent.java
@@ -37,6 +37,7 @@ public class BaseEvent extends BaseEntity {
         this.startDateTime = startDateTime;
         this.endDateTime = endDateTime;
         this.winnerCount = winnerCount;
+        this.totalAppliedCount = new AtomicInteger(0);
     }
 
     public void addAppliedCount(){

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/BaseEvent.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/BaseEvent.java
@@ -9,6 +9,7 @@ import jakarta.persistence.MappedSuperclass;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @Getter
 @MappedSuperclass
@@ -21,12 +22,14 @@ public class BaseEvent extends BaseEntity {
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     protected LocalDateTime endDateTime;
     protected int winnerCount;
+    protected AtomicInteger appliedCount;
 
     // 기본 생성자에서 디폴트 값 설정
     public BaseEvent() {
         this.startDateTime = LocalDateTime.now();
         this.endDateTime = LocalDateTime.now().plusMinutes(10);
         this.winnerCount = 0; // 기본 우승자 수를 0으로 설정
+        this.appliedCount = new AtomicInteger(0);
     }
 
     // 특정 값을 설정할 수 있는 생성자
@@ -34,5 +37,9 @@ public class BaseEvent extends BaseEntity {
         this.startDateTime = startDateTime;
         this.endDateTime = endDateTime;
         this.winnerCount = winnerCount;
+    }
+
+    public void addAppliedCount(){
+        this.appliedCount.addAndGet(1);
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/BaseEvent.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/BaseEvent.java
@@ -22,14 +22,14 @@ public class BaseEvent extends BaseEntity {
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     protected LocalDateTime endDateTime;
     protected int winnerCount;
-    protected AtomicInteger appliedCount;
+    protected AtomicInteger totalAppliedCount;
 
     // 기본 생성자에서 디폴트 값 설정
     public BaseEvent() {
         this.startDateTime = LocalDateTime.now();
         this.endDateTime = LocalDateTime.now().plusMinutes(10);
         this.winnerCount = 0; // 기본 우승자 수를 0으로 설정
-        this.appliedCount = new AtomicInteger(0);
+        this.totalAppliedCount = new AtomicInteger(0);
     }
 
     // 특정 값을 설정할 수 있는 생성자
@@ -40,6 +40,6 @@ public class BaseEvent extends BaseEntity {
     }
 
     public void addAppliedCount(){
-        this.appliedCount.addAndGet(1);
+        this.totalAppliedCount.addAndGet(1);
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/LotteryEvent.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/LotteryEvent.java
@@ -12,13 +12,12 @@ public class LotteryEvent extends BaseEvent {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long lotteryEventId;
 
-    public LotteryEvent(LocalDateTime eventStartDate, LocalDateTime eventEndDate, int winnerCount){
-        this.eventStartDate = eventStartDate;
-        this.eventEndDate = eventEndDate;
+    public LotteryEvent(LocalDateTime eventStartDateTime, LocalDateTime eventEndDateTime, int winnerCount){
+        this.startDateTime = eventStartDateTime;
+        this.endDateTime = eventEndDateTime;
         this.winnerCount = winnerCount;
     }
 
     public LotteryEvent() {
-
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/LotteryEvent.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/LotteryEvent.java
@@ -20,4 +20,11 @@ public class LotteryEvent extends BaseEvent {
 
     public LotteryEvent() {
     }
+
+    public LotteryEvent updateLotteryEvent(LocalDateTime startDateTime, LocalDateTime endDateTime, int winnerCount) {
+        this.startDateTime = startDateTime;
+        this.endDateTime = endDateTime;
+        this.winnerCount = winnerCount;
+        return this;
+    }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/LotteryEvent.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/LotteryEvent.java
@@ -12,9 +12,9 @@ public class LotteryEvent extends BaseEvent {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long lotteryEventId;
 
-    public LotteryEvent(LocalDateTime eventStartDateTime, LocalDateTime eventEndDateTime, int winnerCount){
-        this.startDateTime = eventStartDateTime;
-        this.endDateTime = eventEndDateTime;
+    public LotteryEvent(LocalDateTime startDateTime, LocalDateTime endDateTime, int winnerCount) {
+        this.startDateTime = startDateTime;
+        this.endDateTime = endDateTime;
         this.winnerCount = winnerCount;
     }
 

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/RushEvent.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/RushEvent.java
@@ -36,9 +36,15 @@ public class RushEvent extends BaseEvent {
     }
 
 
-    public RushEvent(LocalDateTime startDateTime, LocalDateTime endDateTime, int winnerCount, String prizeImageUrl, String prizeDescription) {
+    public RushEvent(LocalDateTime startDateTime, LocalDateTime endDateTime,
+                     int winnerCount, String prizeImageUrl, String prizeDescription) {
         super(startDateTime, endDateTime, winnerCount);
         this.prizeImageUrl = prizeImageUrl;
         this.prizeDescription = prizeDescription;
+    }
+
+    public void updateOption(RushOption leftOption, RushOption rightOption){
+        this.options.add(leftOption);
+        this.options.add(rightOption);
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/RushEvent.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/RushEvent.java
@@ -1,6 +1,10 @@
 package JGS.CasperEvent.domain.event.entity.event;
 
+import JGS.CasperEvent.domain.event.dto.RequestDto.rushEventDto.RushEventRequestDto;
 import JGS.CasperEvent.domain.event.entity.participants.RushParticipants;
+import JGS.CasperEvent.global.enums.CustomErrorCode;
+import JGS.CasperEvent.global.enums.Position;
+import JGS.CasperEvent.global.error.exception.CustomException;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -43,8 +47,29 @@ public class RushEvent extends BaseEvent {
         this.prizeDescription = prizeDescription;
     }
 
-    public void addOption(RushOption leftOption, RushOption rightOption){
+    public void addOption(RushOption leftOption, RushOption rightOption) {
         this.options.add(leftOption);
         this.options.add(rightOption);
+    }
+
+    public RushEvent updateRushEvent(RushEventRequestDto requestDto) {
+        this.startDateTime = LocalDateTime.of(requestDto.getEventDate(), requestDto.getStartTime());
+        this.endDateTime = LocalDateTime.of(requestDto.getEventDate(), requestDto.getEndTime());
+        this.winnerCount = requestDto.getWinnerCount();
+        this.prizeDescription = requestDto.getPrizeDescription();
+        this.prizeImageUrl = requestDto.getPrizeImageUrl();
+        return this;
+    }
+
+    public RushOption getLeftOption() {
+        return options.stream()
+                .filter(option -> option.getPosition() == Position.LEFT)
+                .findFirst().orElseThrow(() -> new CustomException(CustomErrorCode.INVALID_RUSH_EVENT_OPTION));
+    }
+
+    public RushOption getRightOption() {
+        return options.stream()
+                .filter(option -> option.getPosition() == Position.RIGHT)
+                .findFirst().orElseThrow(() -> new CustomException(CustomErrorCode.INVALID_RUSH_EVENT_OPTION));
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/RushEvent.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/RushEvent.java
@@ -1,10 +1,12 @@
 package JGS.CasperEvent.domain.event.entity.event;
 
 import JGS.CasperEvent.domain.event.entity.participants.RushParticipants;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.HashSet;
 import java.util.Set;
 
 @Entity
@@ -17,11 +19,11 @@ public class RushEvent extends BaseEvent {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long rushEventId;
 
-    @OneToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL, orphanRemoval = true)
-    @JoinColumn(name = "rush_event_id")
-    private Set<RushOption> options;
+    @OneToMany(fetch = FetchType.EAGER, mappedBy = "rushEvent", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonManagedReference
+    private final Set<RushOption> options = new HashSet<>();
 
-    @OneToMany(mappedBy = "rushEvent", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(fetch = FetchType.EAGER, mappedBy = "rushEvent", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<RushParticipants> rushParticipants;
 
     public RushEvent() {

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/RushEvent.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/RushEvent.java
@@ -43,7 +43,7 @@ public class RushEvent extends BaseEvent {
         this.prizeDescription = prizeDescription;
     }
 
-    public void updateOption(RushOption leftOption, RushOption rightOption){
+    public void addOption(RushOption leftOption, RushOption rightOption){
         this.options.add(leftOption);
         this.options.add(rightOption);
     }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/RushEvent.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/RushEvent.java
@@ -8,6 +8,7 @@ import JGS.CasperEvent.global.error.exception.CustomException;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.ToString;
 
 import java.time.LocalDateTime;
 import java.util.HashSet;
@@ -15,6 +16,7 @@ import java.util.Set;
 
 @Entity
 @Getter
+@ToString
 public class RushEvent extends BaseEvent {
     private String prizeImageUrl;
     private String prizeDescription;

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/RushOption.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/RushOption.java
@@ -1,10 +1,14 @@
 package JGS.CasperEvent.domain.event.entity.event;
 
 import JGS.CasperEvent.global.entity.BaseEntity;
+import JGS.CasperEvent.global.enums.Position;
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
 @NoArgsConstructor
 public class RushOption extends BaseEntity {
     @Id
@@ -13,6 +17,7 @@ public class RushOption extends BaseEntity {
 
     @ManyToOne
     @JoinColumn(name = "rush_event_id")
+    @JsonBackReference
     private RushEvent rushEvent;
     private String mainText;
     private String subText;
@@ -20,12 +25,16 @@ public class RushOption extends BaseEntity {
     private String resultSubText;
     private String imageUrl;
 
-    public RushOption(RushEvent rushEvent, String mainText, String subText, String resultMainText, String resultSubText, String imageUrl) {
+    @Enumerated(EnumType.STRING)
+    private Position position;
+
+    public RushOption(RushEvent rushEvent, String mainText, String subText, String resultMainText, String resultSubText, String imageUrl, Position position) {
         this.rushEvent = rushEvent;
         this.mainText = mainText;
         this.subText = subText;
         this.resultMainText = resultMainText;
         this.resultSubText = resultSubText;
         this.imageUrl = imageUrl;
+        this.position = position;
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/RushOption.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/entity/event/RushOption.java
@@ -1,5 +1,6 @@
 package JGS.CasperEvent.domain.event.entity.event;
 
+import JGS.CasperEvent.domain.event.dto.RequestDto.rushEventDto.RushEventOptionRequestDto;
 import JGS.CasperEvent.global.entity.BaseEntity;
 import JGS.CasperEvent.global.enums.Position;
 import com.fasterxml.jackson.annotation.JsonBackReference;
@@ -36,5 +37,14 @@ public class RushOption extends BaseEntity {
         this.resultSubText = resultSubText;
         this.imageUrl = imageUrl;
         this.position = position;
+    }
+
+    public RushOption updateRushOption(RushEventOptionRequestDto requestDto) {
+        this.mainText = requestDto.getMainText();
+        this.subText = requestDto.getSubText();
+        this.resultMainText = requestDto.getResultMainText();
+        this.resultSubText = requestDto.getResultSubText();
+        this.imageUrl = requestDto.getImageUrl();
+        return this;
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/entity/participants/LotteryParticipants.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/entity/participants/LotteryParticipants.java
@@ -1,5 +1,6 @@
 package JGS.CasperEvent.domain.event.entity.participants;
 
+import JGS.CasperEvent.global.entity.BaseEntity;
 import JGS.CasperEvent.global.entity.BaseUser;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
@@ -7,7 +8,7 @@ import lombok.Getter;
 
 @Getter
 @Entity
-public class LotteryParticipants {
+public class LotteryParticipants extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -33,7 +34,7 @@ public class LotteryParticipants {
     }
 
     public void expectationAdded() {
-        if(expectations == 0) expectations++;
+        if (expectations == 0) expectations++;
         appliedCount = Math.min(10, 1 + expectations + linkClickedCount);
     }
 

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/entity/participants/LotteryWinners.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/entity/participants/LotteryWinners.java
@@ -1,14 +1,22 @@
 package JGS.CasperEvent.domain.event.entity.participants;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Entity
+@Getter
 public class LotteryWinners {
-    @Id
     private long id;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long ranking;
+
     private String phoneNumber;
     private int linkClickedCount;
     private int expectation;

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/entity/participants/LotteryWinners.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/entity/participants/LotteryWinners.java
@@ -1,0 +1,32 @@
+package JGS.CasperEvent.domain.event.entity.participants;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import java.time.LocalDateTime;
+
+@Entity
+public class LotteryWinners {
+    @Id
+    private long id;
+    private String phoneNumber;
+    private int linkClickedCount;
+    private int expectation;
+    private int appliedCount;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public  LotteryWinners(LotteryParticipants lotteryParticipants) {
+        this.id = lotteryParticipants.getId();
+        this.phoneNumber = lotteryParticipants.getBaseUser().getId();
+        this.linkClickedCount = lotteryParticipants.getLinkClickedCount();
+        this.expectation = lotteryParticipants.getExpectations();
+        this.appliedCount = lotteryParticipants.getAppliedCount();
+        this.createdAt = lotteryParticipants.getCreatedAt();
+        this.updatedAt = lotteryParticipants.getUpdatedAt();
+    }
+
+    public LotteryWinners() {
+
+    }
+}

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/entity/participants/RushParticipants.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/entity/participants/RushParticipants.java
@@ -1,12 +1,15 @@
 package JGS.CasperEvent.domain.event.entity.participants;
 
 import JGS.CasperEvent.domain.event.entity.event.RushEvent;
+import JGS.CasperEvent.global.entity.BaseEntity;
 import JGS.CasperEvent.global.entity.BaseUser;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
+import lombok.Getter;
 
 @Entity
-public class RushParticipants {
+@Getter
+public class RushParticipants extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/repository/AdminRepository.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/repository/AdminRepository.java
@@ -4,6 +4,9 @@ import JGS.CasperEvent.domain.event.entity.admin.Admin;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface AdminRepository extends JpaRepository<Admin, String> {
+    Optional<Admin> findByIdAndPassword(String id, String password);
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/repository/CasperBotRepository.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/repository/CasperBotRepository.java
@@ -1,12 +1,17 @@
 package JGS.CasperEvent.domain.event.repository;
 
 import JGS.CasperEvent.domain.event.entity.casperBot.CasperBot;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
 @Repository
 public interface CasperBotRepository extends JpaRepository<CasperBot, Long> {
-    List<CasperBot> findByPhoneNumber(String phoneNumber);
+    @Query("SELECT c FROM CasperBot c WHERE c.phoneNumber = :phoneNumber AND c.isDeleted = false AND c.expectation <> ''")
+    Page<CasperBot> findByPhoneNumberAndActiveExpectations(@Param("phoneNumber") String phoneNumber, Pageable pageable);
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/repository/CasperBotRepository.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/repository/CasperBotRepository.java
@@ -4,6 +4,9 @@ import JGS.CasperEvent.domain.event.entity.casperBot.CasperBot;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface CasperBotRepository extends JpaRepository<CasperBot, Long> {
+    List<CasperBot> findByPhoneNumber(String phoneNumber);
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/repository/participantsRepository/LotteryParticipantsRepository.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/repository/participantsRepository/LotteryParticipantsRepository.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface LotteryParticipantsRepository extends JpaRepository<LotteryParticipants, String> {
+public interface LotteryParticipantsRepository extends JpaRepository<LotteryParticipants, Long> {
     Optional<LotteryParticipants> findByBaseUser(BaseUser baseUser);
 
     Page<LotteryParticipants> findByBaseUser_Id(String id, Pageable pageable);

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/repository/participantsRepository/LotteryParticipantsRepository.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/repository/participantsRepository/LotteryParticipantsRepository.java
@@ -2,6 +2,8 @@ package JGS.CasperEvent.domain.event.repository.participantsRepository;
 
 import JGS.CasperEvent.domain.event.entity.participants.LotteryParticipants;
 import JGS.CasperEvent.global.entity.BaseUser;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -10,5 +12,7 @@ import java.util.Optional;
 @Repository
 public interface LotteryParticipantsRepository extends JpaRepository<LotteryParticipants, String> {
     Optional<LotteryParticipants> findByBaseUser(BaseUser baseUser);
+
+    Page<LotteryParticipants> findByBaseUser_Id(String id, Pageable pageable);
 }
 

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/repository/participantsRepository/LotteryParticipantsRepository.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/repository/participantsRepository/LotteryParticipantsRepository.java
@@ -2,9 +2,11 @@ package JGS.CasperEvent.domain.event.repository.participantsRepository;
 
 import JGS.CasperEvent.domain.event.entity.participants.LotteryParticipants;
 import JGS.CasperEvent.global.entity.BaseUser;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -13,6 +15,10 @@ import java.util.Optional;
 public interface LotteryParticipantsRepository extends JpaRepository<LotteryParticipants, Long> {
     Optional<LotteryParticipants> findByBaseUser(BaseUser baseUser);
 
-    Page<LotteryParticipants> findByBaseUser_Id(String id, Pageable pageable);
+    @Query("SELECT p FROM LotteryParticipants p WHERE p.baseUser.id LIKE :id%")
+    Page<LotteryParticipants> findByBaseUser_Id(@Param("id") String id, Pageable pageable);
+
+    @Query("SELECT COUNT(p) FROM LotteryParticipants p WHERE p.baseUser.id LIKE :id%")
+    long countByBaseUser_Id(@Param("id") String id);
 }
 

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/repository/participantsRepository/LotteryWinnerRepository.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/repository/participantsRepository/LotteryWinnerRepository.java
@@ -1,12 +1,17 @@
 package JGS.CasperEvent.domain.event.repository.participantsRepository;
 
 import JGS.CasperEvent.domain.event.entity.participants.LotteryWinners;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LotteryWinnerRepository extends JpaRepository<LotteryWinners, Long> {
-    Page<LotteryWinners> findByPhoneNumber(String phoneNumber, Pageable pageable);
-}
+    @Query("SELECT w FROM LotteryWinners w WHERE w.phoneNumber LIKE :phoneNumber%")
+    Page<LotteryWinners> findByPhoneNumber(@Param("phoneNumber") String phoneNumber, Pageable pageable);
+
+    @Query("SELECT COUNT(w) FROM LotteryWinners w WHERE w.phoneNumber LIKE :phoneNumber%")
+    long countByPhoneNumber(@Param("phoneNumber") String phoneNumber);}

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/repository/participantsRepository/LotteryWinnerRepository.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/repository/participantsRepository/LotteryWinnerRepository.java
@@ -1,9 +1,12 @@
 package JGS.CasperEvent.domain.event.repository.participantsRepository;
 
 import JGS.CasperEvent.domain.event.entity.participants.LotteryWinners;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface LotteryWinnerRepository extends JpaRepository<LotteryWinners, Long> {
+    Page<LotteryWinners> findByPhoneNumber(String phoneNumber, Pageable pageable);
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/repository/participantsRepository/LotteryWinnerRepository.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/repository/participantsRepository/LotteryWinnerRepository.java
@@ -1,0 +1,9 @@
+package JGS.CasperEvent.domain.event.repository.participantsRepository;
+
+import JGS.CasperEvent.domain.event.entity.participants.LotteryWinners;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface LotteryWinnerRepository extends JpaRepository<LotteryWinners, Long> {
+}

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/repository/participantsRepository/RushParticipantsRepository.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/repository/participantsRepository/RushParticipantsRepository.java
@@ -33,11 +33,13 @@ public interface RushParticipantsRepository extends JpaRepository<RushParticipan
 
     Page<RushParticipants> findByRushEvent_RushEventId(Long rushEventId, Pageable pageable);
 
-    Page<RushParticipants> findByRushEvent_RushEventIdAndBaseUser_Id(Long rushEventId, String baseUser_id, Pageable pageable);
+    @Query("SELECT p FROM RushParticipants p WHERE p.rushEvent.rushEventId = :rushEventId AND p.baseUser.id LIKE :baseUserId%")
+    Page<RushParticipants> findByRushEvent_RushEventIdAndBaseUser_Id(@Param("rushEventId") Long rushEventId, @Param("baseUserId") String baseUserId, Pageable pageable);
 
     Page<RushParticipants> findByRushEvent_RushEventIdAndOptionId(Long rushEventId, int optionId, Pageable pageable);
 
-    Page<RushParticipants> findByRushEvent_RushEventIdAndOptionIdAndBaseUser_Id(Long rushEventId, int optionId, String baseUser_id, Pageable pageable);
+    @Query("SELECT p FROM RushParticipants p WHERE p.rushEvent.rushEventId = :rushEventId AND p.optionId = :optionId AND p.baseUser.id LIKE :baseUserId%")
+    Page<RushParticipants> findByRushEvent_RushEventIdAndOptionIdAndBaseUser_Id(@Param("rushEventId") Long rushEventId, @Param("optionId") int optionId, @Param("baseUserId") String baseUserId, Pageable pageable);
 
 
     @Query("SELECT rp FROM RushParticipants rp " +
@@ -50,7 +52,7 @@ public interface RushParticipantsRepository extends JpaRepository<RushParticipan
     @Query("SELECT rp FROM RushParticipants rp " +
             "WHERE rp.rushEvent.rushEventId = :eventId " +
             "AND rp.optionId = :optionId " +
-            "AND rp.baseUser.id = :phoneNumber " +
+            "AND rp.baseUser.id LIKE :phoneNumber% " +
             "ORDER BY rp.id ASC ")
     Page<RushParticipants> findWinnerByEventIdAndOptionIdAndPhoneNumber(
             @Param("eventId") Long eventId, @Param("optionId") int optionId, @Param("phoneNumber") String phoneNumber, Pageable pageable
@@ -64,14 +66,15 @@ public interface RushParticipantsRepository extends JpaRepository<RushParticipan
 
     @Query("SELECT rp FROM RushParticipants rp " +
             "WHERE rp.rushEvent.rushEventId = :eventId " +
-            "AND rp.baseUser.id = :phoneNumber " +
+            "AND rp.baseUser.id LIKE :phoneNumber% " +
             "ORDER BY rp.id ASC ")
     Page<RushParticipants> findByWinnerByEventIdAndPhoneNumber(@Param("eventId") Long eventId, @Param("phoneNumber") String phoneNumber, Pageable pageable);
 
-    long countByRushEvent_RushEventIdAndOptionIdAndBaseUser_Id(long rushEventId, int optionId, String id);
+    @Query("SELECT COUNT(p) FROM RushParticipants p WHERE p.rushEvent.rushEventId = :rushEventId AND p.optionId = :optionId AND p.baseUser.id LIKE :baseUserId%")
+    long countByRushEvent_RushEventIdAndOptionIdAndBaseUser_Id(@Param("rushEventId") Long rushEventId, @Param("optionId") int optionId, @Param("baseUserId") String baseUserId);
 
     long countByRushEvent_RushEventId(long rushEventId);
 
-    long countByRushEvent_RushEventIdAndBaseUser_Id(long rushEventId, String phoneNumber);
-
+    @Query("SELECT COUNT(p) FROM RushParticipants p WHERE p.rushEvent.rushEventId = :rushEventId AND p.baseUser.id LIKE :baseUserId%")
+    long countByRushEvent_RushEventIdAndBaseUser_Id(@Param("rushEventId") Long rushEventId, @Param("baseUserId") String baseUserId);
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/repository/participantsRepository/RushParticipantsRepository.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/repository/participantsRepository/RushParticipantsRepository.java
@@ -1,6 +1,8 @@
 package JGS.CasperEvent.domain.event.repository.participantsRepository;
 
 import JGS.CasperEvent.domain.event.entity.participants.RushParticipants;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -9,7 +11,7 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface RushParticipantsRepository extends JpaRepository<RushParticipants, String> {
+public interface RushParticipantsRepository extends JpaRepository<RushParticipants, Long> {
     boolean existsByRushEvent_RushEventIdAndBaseUser_Id(Long eventId, String userId);
     long countByRushEvent_RushEventIdAndOptionId(Long eventId, int optionId);
     @Query("SELECT COUNT(rp) + 1 FROM RushParticipants rp " +
@@ -24,5 +26,13 @@ public interface RushParticipantsRepository extends JpaRepository<RushParticipan
     long countAllByOptionId(int optionId);
     @Query("SELECT rp.optionId FROM RushParticipants rp WHERE rp.baseUser.id = :userId")
     Optional<Integer> getOptionIdByUserId(@Param("userId") String userId);
+
+    Page<RushParticipants> findByRushEvent_RushEventId(Long rushEventId, Pageable pageable);
+
+    Page<RushParticipants> findByRushEvent_RushEventIdAndBaseUser_Id(Long rushEventId, String baseUser_id, Pageable pageable);
+
+    Page<RushParticipants> findByRushEvent_RushEventIdAndOptionId(Long rushEventId, int optionId, Pageable pageable);
+
+    Page<RushParticipants> findByRushEvent_RushEventIdAndOptionIdAndBaseUser_Id(Long rushEventId, int optionId, String baseUser_id, Pageable pageable);
 
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/repository/participantsRepository/RushParticipantsRepository.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/repository/participantsRepository/RushParticipantsRepository.java
@@ -67,4 +67,11 @@ public interface RushParticipantsRepository extends JpaRepository<RushParticipan
             "AND rp.baseUser.id = :phoneNumber " +
             "ORDER BY rp.id ASC ")
     Page<RushParticipants> findByWinnerByEventIdAndPhoneNumber(@Param("eventId") Long eventId, @Param("phoneNumber") String phoneNumber, Pageable pageable);
+
+    long countByRushEvent_RushEventIdAndOptionIdAndBaseUser_Id(long rushEventId, int optionId, String id);
+
+    long countByRushEvent_RushEventId(long rushEventId);
+
+    long countByRushEvent_RushEventIdAndBaseUser_Id(long rushEventId, String phoneNumber);
+
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/repository/participantsRepository/RushParticipantsRepository.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/repository/participantsRepository/RushParticipantsRepository.java
@@ -26,6 +26,14 @@ public interface RushParticipantsRepository extends JpaRepository<RushParticipan
                                                    @Param("userId") String userId,
                                                    @Param("optionId") int optionId);
 
+    @Query("SELECT COUNT(rp) + 1 FROM RushParticipants rp " +
+            "WHERE rp.rushEvent.rushEventId = :eventId " +
+            "AND rp.id < (SELECT rp2.id FROM RushParticipants rp2 " +
+            "WHERE rp2.rushEvent.rushEventId = :eventId " +
+            "AND rp2.baseUser.id = :userId)")
+    long findUserRankByEventIdAndUserId(@Param("eventId") Long eventId,
+                                        @Param("userId") String userId);
+
     long countAllByOptionId(int optionId);
 
     @Query("SELECT rp.optionId FROM RushParticipants rp WHERE rp.baseUser.id = :userId")

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/repository/participantsRepository/RushParticipantsRepository.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/repository/participantsRepository/RushParticipantsRepository.java
@@ -13,7 +13,9 @@ import java.util.Optional;
 @Repository
 public interface RushParticipantsRepository extends JpaRepository<RushParticipants, Long> {
     boolean existsByRushEvent_RushEventIdAndBaseUser_Id(Long eventId, String userId);
+
     long countByRushEvent_RushEventIdAndOptionId(Long eventId, int optionId);
+
     @Query("SELECT COUNT(rp) + 1 FROM RushParticipants rp " +
             "WHERE rp.rushEvent.rushEventId = :eventId " +
             "AND rp.optionId = :optionId " +
@@ -23,7 +25,9 @@ public interface RushParticipantsRepository extends JpaRepository<RushParticipan
     long findUserRankByEventIdAndUserIdAndOptionId(@Param("eventId") Long eventId,
                                                    @Param("userId") String userId,
                                                    @Param("optionId") int optionId);
+
     long countAllByOptionId(int optionId);
+
     @Query("SELECT rp.optionId FROM RushParticipants rp WHERE rp.baseUser.id = :userId")
     Optional<Integer> getOptionIdByUserId(@Param("userId") String userId);
 
@@ -35,4 +39,32 @@ public interface RushParticipantsRepository extends JpaRepository<RushParticipan
 
     Page<RushParticipants> findByRushEvent_RushEventIdAndOptionIdAndBaseUser_Id(Long rushEventId, int optionId, String baseUser_id, Pageable pageable);
 
+
+    @Query("SELECT rp FROM RushParticipants rp " +
+            "WHERE rp.rushEvent.rushEventId = :eventId " +
+            "AND rp.optionId = :optionId " +
+            "ORDER BY rp.id ASC ")
+    Page<RushParticipants> findWinnerByEventIdAndOptionId(
+            @Param("eventId") Long eventId, @Param("optionId") int optionId, Pageable pageable);
+
+    @Query("SELECT rp FROM RushParticipants rp " +
+            "WHERE rp.rushEvent.rushEventId = :eventId " +
+            "AND rp.optionId = :optionId " +
+            "AND rp.baseUser.id = :phoneNumber " +
+            "ORDER BY rp.id ASC ")
+    Page<RushParticipants> findWinnerByEventIdAndOptionIdAndPhoneNumber(
+            @Param("eventId") Long eventId, @Param("optionId") int optionId, @Param("phoneNumber") String phoneNumber, Pageable pageable
+    );
+
+    @Query("SELECT rp FROM RushParticipants rp " +
+            "WHERE rp.rushEvent.rushEventId = :eventId " +
+            "ORDER BY rp.id ASC ")
+    Page<RushParticipants> findWinnerByEventId(@Param("eventId") Long eventId, @Param("winnerCount") Pageable pageable);
+
+
+    @Query("SELECT rp FROM RushParticipants rp " +
+            "WHERE rp.rushEvent.rushEventId = :eventId " +
+            "AND rp.baseUser.id = :phoneNumber " +
+            "ORDER BY rp.id ASC ")
+    Page<RushParticipants> findByWinnerByEventIdAndPhoneNumber(@Param("eventId") Long eventId, @Param("phoneNumber") String phoneNumber, Pageable pageable);
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
@@ -52,7 +52,7 @@ public class AdminService {
     private final S3Service s3Service;
 
     public Admin verifyAdmin(AdminRequestDto adminRequestDto) {
-        return adminRepository.findById(adminRequestDto.getAdminId()).orElseThrow(NoSuchElementException::new);
+        return adminRepository.findByIdAndPassword(adminRequestDto.getAdminId(), adminRequestDto.getPassword()).orElseThrow(NoSuchElementException::new);
     }
 
     public ResponseDto postAdmin(AdminRequestDto adminRequestDto) {
@@ -152,5 +152,19 @@ public class AdminService {
     public List<AdminRushEventResponseDto> getRushEvents(){
         List<RushEvent> rushEvents = rushEventRepository.findAll();
         return AdminRushEventResponseDto.of(rushEvents);
+    }
+
+    public void deleteLotteryEvent() {
+        List<LotteryEvent> lotteryEventList = lotteryEventRepository.findAll();
+
+        if (lotteryEventList.isEmpty()) {
+            throw new CustomException("현재 진행중인 lotteryEvent가 존재하지 않습니다.", CustomErrorCode.NO_LOTTERY_EVENT);
+        }
+
+        if (lotteryEventList.size() > 1) {
+            throw new CustomException("현재 진행중인 lotteryEvent가 2개 이상입니다.", CustomErrorCode.TOO_MANY_LOTTERY_EVENT);
+        }
+
+        lotteryEventRepository.deleteAll();
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
@@ -5,11 +5,8 @@ import JGS.CasperEvent.domain.event.dto.RequestDto.lotteryEventDto.LotteryEventR
 import JGS.CasperEvent.domain.event.dto.RequestDto.rushEventDto.RushEventOptionRequestDto;
 import JGS.CasperEvent.domain.event.dto.RequestDto.rushEventDto.RushEventRequestDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.ImageUrlResponseDto;
-import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventDetailResponseDto;
-import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventParticipantsListResponseDto;
-import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventParticipantsResponseDto;
-import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.*;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.AdminRushEventOptionResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.AdminRushEventResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.RushEventParticipantResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.RushEventParticipantsListResponseDto;
@@ -309,6 +306,27 @@ public class AdminService {
         return rushEventResponseDtoList;
     }
 
+    @Transactional
+    public ResponseDto deleteRushEvent(Long rushEventId) {
+        RushEvent rushEvent = rushEventRepository.findById(rushEventId).orElseThrow(() -> new CustomException(CustomErrorCode.NO_RUSH_EVENT));
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime startDateTime = rushEvent.getStartDateTime();
+        LocalDateTime endDateTime = rushEvent.getEndDateTime();
+
+        if (now.isAfter(startDateTime) && now.isBefore(endDateTime))
+            throw new CustomException(CustomErrorCode.EVENT_IN_PROGRESS_CANNOT_DELETE);
+        rushEventRepository.delete(rushEvent);
+        return ResponseDto.of("요청에 성공하였습니다.");
+    }
+
+    public AdminRushEventOptionResponseDto getRushEventOptions(Long rushEventId) {
+        return AdminRushEventOptionResponseDto.of(
+                rushEventRepository.findById(rushEventId).orElseThrow(
+                        () -> new CustomException(CustomErrorCode.NO_RUSH_EVENT)
+                )
+        );
+    }
 
     @Transactional
     public ResponseDto deleteRushEvent(Long rushEventId){

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
@@ -81,8 +81,8 @@ public class AdminService {
         if (lotteryEventRepository.count() >= 1) throw new TooManyLotteryEventException();
 
         LotteryEvent lotteryEvent = lotteryEventRepository.save(new LotteryEvent(
-                LocalDateTime.of(lotteryEventRequestDto.getEventStartDate(), lotteryEventRequestDto.getEventStartTime()),
-                LocalDateTime.of(lotteryEventRequestDto.getEventEndDate(), lotteryEventRequestDto.getEventEndTime()),
+                LocalDateTime.of(lotteryEventRequestDto.getStartDate(), lotteryEventRequestDto.getStartTime()),
+                LocalDateTime.of(lotteryEventRequestDto.getEndDate(), lotteryEventRequestDto.getEndTime()),
                 lotteryEventRequestDto.getWinnerCount()
         ));
 
@@ -214,8 +214,8 @@ public class AdminService {
         LotteryEvent currentLotteryEvent = getCurrentLotteryEvent();
 
         LocalDateTime now = LocalDateTime.now();
-        LocalDateTime newStartDateTime = LocalDateTime.of(lotteryEventRequestDto.getEventStartDate(), lotteryEventRequestDto.getEventStartTime());
-        LocalDateTime newEndDateTime = LocalDateTime.of(lotteryEventRequestDto.getEventEndDate(), lotteryEventRequestDto.getEventEndTime());
+        LocalDateTime newStartDateTime = LocalDateTime.of(lotteryEventRequestDto.getStartDate(), lotteryEventRequestDto.getStartTime());
+        LocalDateTime newEndDateTime = LocalDateTime.of(lotteryEventRequestDto.getEndDate(), lotteryEventRequestDto.getEndTime());
 
         // 종료 날짜가 시작 날짜보다 뒤인지 체크
         if (newEndDateTime.isBefore(newStartDateTime)) {

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
@@ -1,7 +1,7 @@
 package JGS.CasperEvent.domain.event.service.adminService;
 
 import JGS.CasperEvent.domain.event.dto.RequestDto.AdminRequestDto;
-import JGS.CasperEvent.domain.event.dto.RequestDto.LotteryEventRequestDto;
+import JGS.CasperEvent.domain.event.dto.RequestDto.lotteryEventDto.LotteryEventRequestDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventDetailResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventParticipantsListResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventParticipantsResponseDto;
@@ -16,7 +16,6 @@ import JGS.CasperEvent.domain.event.repository.participantsRepository.LotteryPar
 import JGS.CasperEvent.global.enums.CustomErrorCode;
 import JGS.CasperEvent.global.enums.Role;
 import JGS.CasperEvent.global.error.exception.CustomException;
-import JGS.CasperEvent.global.error.exception.LotteryEventNotExists;
 import JGS.CasperEvent.global.error.exception.TooManyLotteryEventException;
 import JGS.CasperEvent.global.response.ResponseDto;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +28,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
@@ -11,7 +11,6 @@ import JGS.CasperEvent.domain.event.entity.event.LotteryEvent;
 import JGS.CasperEvent.domain.event.entity.participants.LotteryParticipants;
 import JGS.CasperEvent.domain.event.repository.AdminRepository;
 import JGS.CasperEvent.domain.event.repository.eventRepository.LotteryEventRepository;
-import JGS.CasperEvent.domain.event.repository.eventRepository.RushEventRepository;
 import JGS.CasperEvent.domain.event.repository.participantsRepository.LotteryParticipantsRepository;
 import JGS.CasperEvent.global.enums.CustomErrorCode;
 import JGS.CasperEvent.global.enums.Role;
@@ -35,7 +34,6 @@ public class AdminService {
 
     private final AdminRepository adminRepository;
     private final LotteryEventRepository lotteryEventRepository;
-    private final RushEventRepository rushEventRepository;
     private final LotteryParticipantsRepository lotteryParticipantsRepository;
 
     public Admin verifyAdmin(AdminRequestDto adminRequestDto) {

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
@@ -6,10 +6,7 @@ import JGS.CasperEvent.domain.event.dto.RequestDto.rushEventDto.RushEventOptionR
 import JGS.CasperEvent.domain.event.dto.RequestDto.rushEventDto.RushEventRequestDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.ImageUrlResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.*;
-import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.AdminRushEventOptionResponseDto;
-import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.AdminRushEventResponseDto;
-import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.RushEventParticipantResponseDto;
-import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.RushEventParticipantsListResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.*;
 import JGS.CasperEvent.domain.event.entity.admin.Admin;
 import JGS.CasperEvent.domain.event.entity.casperBot.CasperBot;
 import JGS.CasperEvent.domain.event.entity.event.LotteryEvent;
@@ -320,7 +317,7 @@ public class AdminService {
     }
 
     @Transactional
-    public ResponseDto pickWinners() {
+    public ResponseDto pickLotteryEventWinners() {
         if(lotteryWinnerRepository.count() > 1) throw new CustomException(CustomErrorCode.LOTTERY_EVENT_ALREADY_DRAWN);
         LotteryEvent lotteryEvent = getCurrentLotteryEvent();
 
@@ -335,6 +332,25 @@ public class AdminService {
         }
 
         return new ResponseDto("추첨이 완료되었습니다.");
+    }
+
+    public LotteryEventWinnerListResponseDto getLotteryEventWinners(int size, int page, String phoneNumber){
+        Pageable pageable = PageRequest.of(page, size);
+        if(lotteryWinnerRepository.count() == 0) throw new CustomException(CustomErrorCode.LOTTERY_EVENT_NOT_DRAWN);
+
+        Page<LotteryWinners> lotteryWinnersPage = null;
+        if (phoneNumber.isEmpty()) lotteryWinnersPage = lotteryWinnerRepository.findAll(pageable);
+        else lotteryWinnersPage = lotteryWinnerRepository.findByPhoneNumber(phoneNumber, pageable);
+
+        List<LotteryEventWinnerResponseDto> lotteryEventWinnerResponseDto = new ArrayList<>();
+
+        for (LotteryWinners lotteryWinners : lotteryWinnersPage) {
+            lotteryEventWinnerResponseDto.add(
+                    LotteryEventWinnerResponseDto.of(lotteryWinners)
+            );
+        }
+        Boolean isLastPage = !lotteryWinnersPage.hasNext();
+        return new LotteryEventWinnerListResponseDto(lotteryEventWinnerResponseDto, isLastPage, lotteryWinnerRepository.count());
     }
 
     @Transactional

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
@@ -45,8 +45,8 @@ public class AdminService {
 
     public LotteryEventResponseDto createLotteryEvent(LotteryEventRequestDto lotteryEventRequestDto) {
         LotteryEvent lotteryEvent = lotteryEventRepository.save(new LotteryEvent(
-                lotteryEventRequestDto.getEventStartDate(),
-                lotteryEventRequestDto.getEventEndDate(),
+                lotteryEventRequestDto.getEventStartDateTime(),
+                lotteryEventRequestDto.getEventEndDateTime(),
                 lotteryEventRequestDto.getWinnerCount()
         ));
 

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
@@ -102,8 +102,14 @@ public class AdminService {
         Pageable pageable = PageRequest.of(page, size);
 
         Page<LotteryParticipants> lotteryParticipantsPage = null;
-        if (phoneNumber.isEmpty()) lotteryParticipantsPage = lotteryParticipantsRepository.findAll(pageable);
-        else lotteryParticipantsPage = lotteryParticipantsRepository.findByBaseUser_Id(phoneNumber, pageable);
+        long count;
+        if (phoneNumber.isEmpty()) {
+            lotteryParticipantsPage = lotteryParticipantsRepository.findAll(pageable);
+            count = lotteryParticipantsRepository.count();
+        } else {
+            lotteryParticipantsPage = lotteryParticipantsRepository.findByBaseUser_Id(phoneNumber, pageable);
+            count = lotteryParticipantsRepository.countByBaseUser_Id(phoneNumber);
+        }
 
         List<LotteryEventParticipantsResponseDto> lotteryEventParticipantsResponseDtoList = new ArrayList<>();
 
@@ -113,7 +119,7 @@ public class AdminService {
             );
         }
         Boolean isLastPage = !lotteryParticipantsPage.hasNext();
-        return new LotteryEventParticipantsListResponseDto(lotteryEventParticipantsResponseDtoList, isLastPage, lotteryParticipantsRepository.count());
+        return new LotteryEventParticipantsListResponseDto(lotteryEventParticipantsResponseDtoList, isLastPage, count);
     }
 
     public AdminRushEventResponseDto createRushEvent(RushEventRequestDto rushEventRequestDto, MultipartFile prizeImg, MultipartFile leftOptionImg, MultipartFile rightOptionImg) {
@@ -209,7 +215,6 @@ public class AdminService {
         }
 
         Boolean isLastPage = !rushParticipantsPage.hasNext();
-        // todo 전체 참여자 아닌 옵션별 참여자로 수정하기
         return new RushEventParticipantsListResponseDto(rushEventParticipantResponseDtoList, isLastPage, count);
     }
 
@@ -318,7 +323,7 @@ public class AdminService {
 
     @Transactional
     public ResponseDto pickLotteryEventWinners() {
-        if(lotteryWinnerRepository.count() > 1) throw new CustomException(CustomErrorCode.LOTTERY_EVENT_ALREADY_DRAWN);
+        if (lotteryWinnerRepository.count() > 1) throw new CustomException(CustomErrorCode.LOTTERY_EVENT_ALREADY_DRAWN);
         LotteryEvent lotteryEvent = getCurrentLotteryEvent();
 
         int winnerCount = lotteryEvent.getWinnerCount();
@@ -334,13 +339,19 @@ public class AdminService {
         return new ResponseDto("추첨이 완료되었습니다.");
     }
 
-    public LotteryEventWinnerListResponseDto getLotteryEventWinners(int size, int page, String phoneNumber){
+    public LotteryEventWinnerListResponseDto getLotteryEventWinners(int size, int page, String phoneNumber) {
         Pageable pageable = PageRequest.of(page, size);
-        if(lotteryWinnerRepository.count() == 0) throw new CustomException(CustomErrorCode.LOTTERY_EVENT_NOT_DRAWN);
+        if (lotteryWinnerRepository.count() == 0) throw new CustomException(CustomErrorCode.LOTTERY_EVENT_NOT_DRAWN);
 
         Page<LotteryWinners> lotteryWinnersPage = null;
-        if (phoneNumber.isEmpty()) lotteryWinnersPage = lotteryWinnerRepository.findAll(pageable);
-        else lotteryWinnersPage = lotteryWinnerRepository.findByPhoneNumber(phoneNumber, pageable);
+        long count;
+        if (phoneNumber.isEmpty()) {
+            lotteryWinnersPage = lotteryWinnerRepository.findAll(pageable);
+            count = lotteryWinnerRepository.count();
+        } else {
+            lotteryWinnersPage = lotteryWinnerRepository.findByPhoneNumber(phoneNumber, pageable);
+            count = lotteryWinnerRepository.countByPhoneNumber(phoneNumber);
+        }
 
         List<LotteryEventWinnerResponseDto> lotteryEventWinnerResponseDto = new ArrayList<>();
 
@@ -350,7 +361,7 @@ public class AdminService {
             );
         }
         Boolean isLastPage = !lotteryWinnersPage.hasNext();
-        return new LotteryEventWinnerListResponseDto(lotteryEventWinnerResponseDto, isLastPage, lotteryWinnerRepository.count());
+        return new LotteryEventWinnerListResponseDto(lotteryEventWinnerResponseDto, isLastPage, count);
     }
 
     @Transactional

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
@@ -4,6 +4,7 @@ import JGS.CasperEvent.domain.event.dto.RequestDto.AdminRequestDto;
 import JGS.CasperEvent.domain.event.dto.RequestDto.lotteryEventDto.LotteryEventRequestDto;
 import JGS.CasperEvent.domain.event.dto.RequestDto.rushEventDto.RushEventOptionRequestDto;
 import JGS.CasperEvent.domain.event.dto.RequestDto.rushEventDto.RushEventRequestDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.ImageUrlResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventDetailResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventParticipantsListResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventParticipantsResponseDto;
@@ -72,6 +73,10 @@ public class AdminService {
         adminRepository.save(new Admin(adminId, password, Role.ADMIN));
 
         return ResponseDto.of("관리자 생성 성공");
+    }
+
+    public ImageUrlResponseDto postImage(MultipartFile image){
+        return new ImageUrlResponseDto(s3Service.upload(image));
     }
 
     public LotteryEventResponseDto createLotteryEvent(LotteryEventRequestDto lotteryEventRequestDto) {
@@ -150,7 +155,7 @@ public class AdminService {
                 Position.RIGHT
         ));
 
-        rushEvent.updateOption(leftRushOption, rightRushOption);
+        rushEvent.addOption(leftRushOption, rightRushOption);
 
         return RushEventResponseDto.of(rushEvent);
     }
@@ -253,5 +258,11 @@ public class AdminService {
         }
 
         return lotteryEventList.get(0);
+    }
+
+    public List<AdminRushEventResponseDto> updateRushEvents(List<RushEventRequestDto> rushEventRequestDtoList, List<MultipartFile> images) {
+        LocalDateTime now = LocalDateTime.now();
+
+        return null;
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
@@ -328,20 +328,6 @@ public class AdminService {
         );
     }
 
-    @Transactional
-    public ResponseDto deleteRushEvent(Long rushEventId){
-        RushEvent rushEvent = rushEventRepository.findById(rushEventId).orElseThrow(() -> new CustomException(CustomErrorCode.NO_RUSH_EVENT));
-
-        LocalDateTime now = LocalDateTime.now();
-        LocalDateTime startDateTime = rushEvent.getStartDateTime();
-        LocalDateTime endDateTime = rushEvent.getEndDateTime();
-
-        if(now.isAfter(startDateTime) && now.isBefore(endDateTime))
-            throw new CustomException(CustomErrorCode.EVENT_IN_PROGRESS_CANNOT_DELETE);
-        rushEventRepository.delete(rushEvent);
-        return ResponseDto.of("요청에 성공하였습니다.");
-    }
-
     public List<LotteryEventExpectationResponseDto> getLotteryEventExpectations(Long participantId) {
         LotteryParticipants lotteryParticipant = lotteryParticipantsRepository.findById(participantId).orElseThrow(
                 () -> new CustomException(CustomErrorCode.USER_NOT_FOUND)

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
@@ -8,6 +8,7 @@ import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.Lott
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventParticipantsListResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventParticipantsResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.AdminRushEventResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.RushEventResponseDto;
 import JGS.CasperEvent.domain.event.entity.admin.Admin;
 import JGS.CasperEvent.domain.event.entity.event.LotteryEvent;
@@ -146,5 +147,10 @@ public class AdminService {
         rushEvent.updateOption(leftRushOption, rightRushOption);
 
         return RushEventResponseDto.of(rushEvent);
+    }
+
+    public List<AdminRushEventResponseDto> getRushEvents(){
+        List<RushEvent> rushEvents = rushEventRepository.findAll();
+        return AdminRushEventResponseDto.of(rushEvents);
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
@@ -2,6 +2,7 @@ package JGS.CasperEvent.domain.event.service.adminService;
 
 import JGS.CasperEvent.domain.event.dto.RequestDto.AdminRequestDto;
 import JGS.CasperEvent.domain.event.dto.RequestDto.LotteryEventRequestDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.LotteryEventDetailResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.LotteryEventResponseDto;
 import JGS.CasperEvent.domain.event.entity.admin.Admin;
 import JGS.CasperEvent.domain.event.entity.event.LotteryEvent;
@@ -11,11 +12,13 @@ import JGS.CasperEvent.domain.event.repository.eventRepository.RushEventReposito
 import JGS.CasperEvent.global.enums.CustomErrorCode;
 import JGS.CasperEvent.global.enums.Role;
 import JGS.CasperEvent.global.error.exception.CustomException;
+import JGS.CasperEvent.global.error.exception.TooManyLotteryEventException;
 import JGS.CasperEvent.global.response.ResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.NoSuchElementException;
 
 @RequiredArgsConstructor
@@ -44,6 +47,8 @@ public class AdminService {
     }
 
     public LotteryEventResponseDto createLotteryEvent(LotteryEventRequestDto lotteryEventRequestDto) {
+        if(lotteryEventRepository.count() >= 1) throw new TooManyLotteryEventException();
+
         LotteryEvent lotteryEvent = lotteryEventRepository.save(new LotteryEvent(
                 lotteryEventRequestDto.getEventStartDateTime(),
                 lotteryEventRequestDto.getEventEndDateTime(),
@@ -51,5 +56,11 @@ public class AdminService {
         ));
 
         return LotteryEventResponseDto.of(lotteryEvent, LocalDateTime.now());
+    }
+
+    public List<LotteryEventDetailResponseDto> getLotteryEvent() {
+        return LotteryEventDetailResponseDto.of(
+                lotteryEventRepository.findAll()
+        );
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
@@ -177,20 +177,26 @@ public class AdminService {
 
         boolean isPhoneNumberEmpty = phoneNumber.isEmpty();
         boolean isOptionIdValid = optionId == 1 || optionId == 2;
+        long count;
 
         if (!isPhoneNumberEmpty && isOptionIdValid) {
             // 전화번호와 유효한 옵션 ID가 있는 경우
             rushParticipantsPage = rushParticipantsRepository.findByRushEvent_RushEventIdAndOptionIdAndBaseUser_Id(rushEventId, optionId, phoneNumber, pageable);
+            count = rushParticipantsRepository.countByRushEvent_RushEventIdAndOptionIdAndBaseUser_Id(rushEventId, optionId, phoneNumber);
         } else if (isPhoneNumberEmpty && !isOptionIdValid) {
             // 전화번호가 비어있고 유효하지 않은 옵션 ID가 있는 경우
             rushParticipantsPage = rushParticipantsRepository.findByRushEvent_RushEventId(rushEventId, pageable);
+            count = rushParticipantsRepository.countByRushEvent_RushEventId(rushEventId);
         } else if (isOptionIdValid) {
             // 유효한 옵션 ID가 있지만 전화번호는 비어있는 경우
             rushParticipantsPage = rushParticipantsRepository.findByRushEvent_RushEventIdAndOptionId(rushEventId, optionId, pageable);
+            count = rushParticipantsRepository.countByRushEvent_RushEventIdAndOptionId(rushEventId, optionId);
         } else {
             // 유효하지 않은 옵션 ID와 전화번호가 주어진 경우
             rushParticipantsPage = rushParticipantsRepository.findByRushEvent_RushEventIdAndBaseUser_Id(rushEventId, phoneNumber, pageable);
+            count = rushParticipantsRepository.countByRushEvent_RushEventIdAndBaseUser_Id(rushEventId, phoneNumber);
         }
+
 
         List<RushEventParticipantResponseDto> rushEventParticipantResponseDtoList = new ArrayList<>();
         for (RushParticipants rushParticipant : rushParticipantsPage) {
@@ -204,7 +210,7 @@ public class AdminService {
 
         Boolean isLastPage = !rushParticipantsPage.hasNext();
         // todo 전체 참여자 아닌 옵션별 참여자로 수정하기
-        return new RushEventParticipantsListResponseDto(rushEventParticipantResponseDtoList, isLastPage, rushParticipantsRepository.count());
+        return new RushEventParticipantsListResponseDto(rushEventParticipantResponseDtoList, isLastPage, count);
     }
 
     public RushEventParticipantsListResponseDto getRushEventWinners(long rushEventId, int size, int page, String phoneNumber) {

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
@@ -2,24 +2,34 @@ package JGS.CasperEvent.domain.event.service.adminService;
 
 import JGS.CasperEvent.domain.event.dto.RequestDto.AdminRequestDto;
 import JGS.CasperEvent.domain.event.dto.RequestDto.LotteryEventRequestDto;
-import JGS.CasperEvent.domain.event.dto.ResponseDto.LotteryEventDetailResponseDto;
-import JGS.CasperEvent.domain.event.dto.ResponseDto.LotteryEventResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventDetailResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventParticipantsListResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventParticipantsResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventResponseDto;
 import JGS.CasperEvent.domain.event.entity.admin.Admin;
 import JGS.CasperEvent.domain.event.entity.event.LotteryEvent;
+import JGS.CasperEvent.domain.event.entity.participants.LotteryParticipants;
 import JGS.CasperEvent.domain.event.repository.AdminRepository;
 import JGS.CasperEvent.domain.event.repository.eventRepository.LotteryEventRepository;
 import JGS.CasperEvent.domain.event.repository.eventRepository.RushEventRepository;
+import JGS.CasperEvent.domain.event.repository.participantsRepository.LotteryParticipantsRepository;
 import JGS.CasperEvent.global.enums.CustomErrorCode;
 import JGS.CasperEvent.global.enums.Role;
 import JGS.CasperEvent.global.error.exception.CustomException;
+import JGS.CasperEvent.global.error.exception.LotteryEventNotExists;
 import JGS.CasperEvent.global.error.exception.TooManyLotteryEventException;
 import JGS.CasperEvent.global.response.ResponseDto;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 
 @RequiredArgsConstructor
 @Service
@@ -28,6 +38,7 @@ public class AdminService {
     private final AdminRepository adminRepository;
     private final LotteryEventRepository lotteryEventRepository;
     private final RushEventRepository rushEventRepository;
+    private final LotteryParticipantsRepository lotteryParticipantsRepository;
 
     public Admin verifyAdmin(AdminRequestDto adminRequestDto) {
         return adminRepository.findById(adminRequestDto.getAdminId()).orElseThrow(NoSuchElementException::new);
@@ -47,7 +58,7 @@ public class AdminService {
     }
 
     public LotteryEventResponseDto createLotteryEvent(LotteryEventRequestDto lotteryEventRequestDto) {
-        if(lotteryEventRepository.count() >= 1) throw new TooManyLotteryEventException();
+        if (lotteryEventRepository.count() >= 1) throw new TooManyLotteryEventException();
 
         LotteryEvent lotteryEvent = lotteryEventRepository.save(new LotteryEvent(
                 lotteryEventRequestDto.getEventStartDateTime(),
@@ -62,5 +73,26 @@ public class AdminService {
         return LotteryEventDetailResponseDto.of(
                 lotteryEventRepository.findAll()
         );
+    }
+
+    public LotteryEventParticipantsListResponseDto getLotteryEventParticipants(int size, int page, String phoneNumber) {
+        Pageable pageable = PageRequest.of(page, size);
+
+        Page<LotteryParticipants> lotteryParticipantsPage = null;
+        if (phoneNumber.isEmpty()) lotteryParticipantsPage = lotteryParticipantsRepository.findAll(pageable);
+        else lotteryParticipantsRepository.findByBaseUser_Id(phoneNumber, pageable);
+
+        for (LotteryParticipants participants : lotteryParticipantsPage) {
+            System.out.println("participants = " + participants);
+        }
+        List<LotteryEventParticipantsResponseDto> lotteryEventParticipantsResponseDtoList = new ArrayList<>();
+
+        for (LotteryParticipants lotteryParticipant : lotteryParticipantsPage) {
+            lotteryEventParticipantsResponseDtoList.add(
+                    LotteryEventParticipantsResponseDto.of(lotteryParticipant)
+            );
+        }
+        Boolean isLastPage = !lotteryParticipantsPage.hasNext();
+        return new LotteryEventParticipantsListResponseDto(lotteryEventParticipantsResponseDtoList, isLastPage, lotteryParticipantsRepository.count());
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
@@ -2,26 +2,37 @@ package JGS.CasperEvent.domain.event.service.adminService;
 
 import JGS.CasperEvent.domain.event.dto.RequestDto.AdminRequestDto;
 import JGS.CasperEvent.domain.event.dto.RequestDto.lotteryEventDto.LotteryEventRequestDto;
+import JGS.CasperEvent.domain.event.dto.RequestDto.rushEventDto.RushEventOptionRequestDto;
+import JGS.CasperEvent.domain.event.dto.RequestDto.rushEventDto.RushEventRequestDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventDetailResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventParticipantsListResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventParticipantsResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.RushEventResponseDto;
 import JGS.CasperEvent.domain.event.entity.admin.Admin;
 import JGS.CasperEvent.domain.event.entity.event.LotteryEvent;
+import JGS.CasperEvent.domain.event.entity.event.RushEvent;
+import JGS.CasperEvent.domain.event.entity.event.RushOption;
 import JGS.CasperEvent.domain.event.entity.participants.LotteryParticipants;
 import JGS.CasperEvent.domain.event.repository.AdminRepository;
 import JGS.CasperEvent.domain.event.repository.eventRepository.LotteryEventRepository;
+import JGS.CasperEvent.domain.event.repository.eventRepository.RushEventRepository;
+import JGS.CasperEvent.domain.event.repository.eventRepository.RushOptionRepository;
 import JGS.CasperEvent.domain.event.repository.participantsRepository.LotteryParticipantsRepository;
 import JGS.CasperEvent.global.enums.CustomErrorCode;
+import JGS.CasperEvent.global.enums.Position;
 import JGS.CasperEvent.global.enums.Role;
 import JGS.CasperEvent.global.error.exception.CustomException;
 import JGS.CasperEvent.global.error.exception.TooManyLotteryEventException;
+import JGS.CasperEvent.global.error.exception.TooManyRushEventException;
 import JGS.CasperEvent.global.response.ResponseDto;
+import JGS.CasperEvent.global.service.S3Service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -34,7 +45,10 @@ public class AdminService {
 
     private final AdminRepository adminRepository;
     private final LotteryEventRepository lotteryEventRepository;
+    private final RushEventRepository rushEventRepository;
     private final LotteryParticipantsRepository lotteryParticipantsRepository;
+    private final RushOptionRepository rushOptionRepository;
+    private final S3Service s3Service;
 
     public Admin verifyAdmin(AdminRequestDto adminRequestDto) {
         return adminRepository.findById(adminRequestDto.getAdminId()).orElseThrow(NoSuchElementException::new);
@@ -78,9 +92,6 @@ public class AdminService {
         if (phoneNumber.isEmpty()) lotteryParticipantsPage = lotteryParticipantsRepository.findAll(pageable);
         else lotteryParticipantsRepository.findByBaseUser_Id(phoneNumber, pageable);
 
-        for (LotteryParticipants participants : lotteryParticipantsPage) {
-            System.out.println("participants = " + participants);
-        }
         List<LotteryEventParticipantsResponseDto> lotteryEventParticipantsResponseDtoList = new ArrayList<>();
 
         for (LotteryParticipants lotteryParticipant : lotteryParticipantsPage) {
@@ -90,5 +101,50 @@ public class AdminService {
         }
         Boolean isLastPage = !lotteryParticipantsPage.hasNext();
         return new LotteryEventParticipantsListResponseDto(lotteryEventParticipantsResponseDtoList, isLastPage, lotteryParticipantsRepository.count());
+    }
+
+    public RushEventResponseDto createRushEvent(RushEventRequestDto rushEventRequestDto, MultipartFile prizeImg, MultipartFile leftOptionImg, MultipartFile rightOptionImg) {
+        if (rushEventRepository.count() >= 6) throw new TooManyRushEventException();
+
+        String prizeImgSrc = s3Service.upload(prizeImg);
+        String leftOptionImgSrc = s3Service.upload(leftOptionImg);
+        String rightOptionImgSrc = s3Service.upload(rightOptionImg);
+
+        // Img s3 저장
+        RushEvent rushEvent = rushEventRepository.save(
+                new RushEvent(
+                        LocalDateTime.of(rushEventRequestDto.getEventDate(), rushEventRequestDto.getStartTime()),
+                        LocalDateTime.of(rushEventRequestDto.getEventDate(), rushEventRequestDto.getEndTime()),
+                        rushEventRequestDto.getWinnerCount(),
+                        prizeImgSrc,
+                        rushEventRequestDto.getPrizeDescription()
+                ));
+
+        RushEventOptionRequestDto leftOption = rushEventRequestDto.getLeftOption();
+        RushEventOptionRequestDto rightOption = rushEventRequestDto.getRightOption();
+
+        RushOption leftRushOption = rushOptionRepository.save(new RushOption(
+                rushEvent,
+                leftOption.getMainText(),
+                leftOption.getSubText(),
+                leftOption.getResultMainText(),
+                leftOption.getResultSubText(),
+                leftOptionImgSrc,
+                Position.LEFT
+        ));
+
+        RushOption rightRushOption = rushOptionRepository.save(new RushOption(
+                rushEvent,
+                rightOption.getMainText(),
+                rightOption.getSubText(),
+                rightOption.getResultMainText(),
+                rightOption.getResultSubText(),
+                rightOptionImgSrc,
+                Position.RIGHT
+        ));
+
+        rushEvent.updateOption(leftRushOption, rightRushOption);
+
+        return RushEventResponseDto.of(rushEvent);
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
@@ -9,17 +9,21 @@ import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.Lott
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventParticipantsResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.AdminRushEventResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.RushEventParticipantResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.RushEventParticipantsListResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.RushEventResponseDto;
 import JGS.CasperEvent.domain.event.entity.admin.Admin;
 import JGS.CasperEvent.domain.event.entity.event.LotteryEvent;
 import JGS.CasperEvent.domain.event.entity.event.RushEvent;
 import JGS.CasperEvent.domain.event.entity.event.RushOption;
 import JGS.CasperEvent.domain.event.entity.participants.LotteryParticipants;
+import JGS.CasperEvent.domain.event.entity.participants.RushParticipants;
 import JGS.CasperEvent.domain.event.repository.AdminRepository;
 import JGS.CasperEvent.domain.event.repository.eventRepository.LotteryEventRepository;
 import JGS.CasperEvent.domain.event.repository.eventRepository.RushEventRepository;
 import JGS.CasperEvent.domain.event.repository.eventRepository.RushOptionRepository;
 import JGS.CasperEvent.domain.event.repository.participantsRepository.LotteryParticipantsRepository;
+import JGS.CasperEvent.domain.event.repository.participantsRepository.RushParticipantsRepository;
 import JGS.CasperEvent.global.enums.CustomErrorCode;
 import JGS.CasperEvent.global.enums.Position;
 import JGS.CasperEvent.global.enums.Role;
@@ -48,6 +52,7 @@ public class AdminService {
     private final LotteryEventRepository lotteryEventRepository;
     private final RushEventRepository rushEventRepository;
     private final LotteryParticipantsRepository lotteryParticipantsRepository;
+    private final RushParticipantsRepository rushParticipantsRepository;
     private final RushOptionRepository rushOptionRepository;
     private final S3Service s3Service;
 
@@ -80,9 +85,9 @@ public class AdminService {
         return LotteryEventResponseDto.of(lotteryEvent, LocalDateTime.now());
     }
 
-    public List<LotteryEventDetailResponseDto> getLotteryEvent() {
+    public LotteryEventDetailResponseDto getLotteryEvent() {
         return LotteryEventDetailResponseDto.of(
-                lotteryEventRepository.findAll()
+                lotteryEventRepository.findAll().get(0)
         );
     }
 
@@ -149,11 +154,47 @@ public class AdminService {
         return RushEventResponseDto.of(rushEvent);
     }
 
-    public List<AdminRushEventResponseDto> getRushEvents(){
+    public List<AdminRushEventResponseDto> getRushEvents() {
         List<RushEvent> rushEvents = rushEventRepository.findAll();
         return AdminRushEventResponseDto.of(rushEvents);
     }
 
+    public RushEventParticipantsListResponseDto getRushEventParticipants(long rushEventId, int size, int page, int optionId, String phoneNumber) {
+        Pageable pageable = PageRequest.of(page, size);
+
+        Page<RushParticipants> rushParticipantsPage = null;
+
+        boolean isPhoneNumberEmpty = phoneNumber.isEmpty();
+        boolean isOptionIdValid = optionId == 1 || optionId == 2;
+
+        if (!isPhoneNumberEmpty && isOptionIdValid) {
+            // 전화번호와 유효한 옵션 ID가 있는 경우
+            rushParticipantsPage = rushParticipantsRepository.findByRushEvent_RushEventIdAndOptionIdAndBaseUser_Id(rushEventId, optionId, phoneNumber, pageable);
+        } else if (isPhoneNumberEmpty && !isOptionIdValid) {
+            // 전화번호가 비어있고 유효하지 않은 옵션 ID가 있는 경우
+            rushParticipantsPage = rushParticipantsRepository.findByRushEvent_RushEventId(rushEventId, pageable);
+        } else if (isOptionIdValid) {
+            // 유효한 옵션 ID가 있지만 전화번호는 비어있는 경우
+            rushParticipantsPage = rushParticipantsRepository.findByRushEvent_RushEventIdAndOptionId(rushEventId, optionId, pageable);
+        } else {
+            // 유효하지 않은 옵션 ID와 전화번호가 주어진 경우
+            rushParticipantsPage = rushParticipantsRepository.findByRushEvent_RushEventIdAndBaseUser_Id(rushEventId, phoneNumber, pageable);
+        }
+
+        List<RushEventParticipantResponseDto> rushEventParticipantResponseDtoList = new ArrayList<>();
+        for (RushParticipants rushParticipant : rushParticipantsPage) {
+            String userId = rushParticipant.getBaseUser().getId();
+            int userChoice = rushParticipant.getOptionId();
+            long rank = rushParticipantsRepository.findUserRankByEventIdAndUserIdAndOptionId(rushEventId, userId, userChoice);
+            rushEventParticipantResponseDtoList.add(
+                    RushEventParticipantResponseDto.of(rushParticipant, rank)
+            );
+        }
+
+        Boolean isLastPage = !rushParticipantsPage.hasNext();
+        return new RushEventParticipantsListResponseDto(rushEventParticipantResponseDtoList, isLastPage, rushParticipantsRepository.count());
+    }
+  
     public void deleteLotteryEvent() {
         List<LotteryEvent> lotteryEventList = lotteryEventRepository.findAll();
 

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
@@ -331,15 +331,40 @@ public class AdminService {
 
         int winnerCount = lotteryEvent.getWinnerCount();
 
-        Pageable pageable = PageRequest.of(0, winnerCount);
+        List<LotteryParticipants> lotteryParticipants = lotteryParticipantsRepository.findAll();
+        Set<LotteryParticipants> lotteryEventWinners = new HashSet<>();
 
-        //todo 당첨자 추첨 알고리즘 변경해야함
-        Page<LotteryParticipants> lotteryWinners = lotteryParticipantsRepository.findAll(pageable);
-        for (LotteryParticipants lotteryWinner : lotteryWinners) {
-            lotteryWinnerRepository.save(new LotteryWinners(lotteryWinner));
+        int totalWeight;
+        Random random = new Random();
+        while (lotteryEventWinners.size() < winnerCount) {
+            totalWeight = 0;
+            for (LotteryParticipants lotteryParticipant : lotteryParticipants) {
+                totalWeight += lotteryParticipant.getAppliedCount();
+            }
+
+            int randomValue = random.nextInt(totalWeight) + 1;
+
+            int cumulativeSum = 0;
+            for (LotteryParticipants lotteryParticipant : lotteryParticipants) {
+                cumulativeSum += lotteryParticipant.getAppliedCount();
+                if(randomValue <= cumulativeSum){
+                    lotteryEventWinners.add(lotteryParticipant);
+                    lotteryParticipants.remove(lotteryParticipant);
+                    break;
+                }
+            }
+        }
+
+        for (LotteryParticipants lotteryEventWinner : lotteryEventWinners) {
+            lotteryWinnerRepository.save(new LotteryWinners(lotteryEventWinner));
         }
 
         return new ResponseDto("추첨이 완료되었습니다.");
+    }
+
+    public ResponseDto deleteLotteryEventWinners(){
+        lotteryWinnerRepository.deleteAll();
+        return new ResponseDto("당첨자 명단을 삭제했습니다.");
     }
 
     public LotteryEventWinnerListResponseDto getLotteryEventWinners(int size, int page, String phoneNumber) {

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/adminService/AdminService.java
@@ -310,6 +310,20 @@ public class AdminService {
     }
 
 
+    @Transactional
+    public ResponseDto deleteRushEvent(Long rushEventId){
+        RushEvent rushEvent = rushEventRepository.findById(rushEventId).orElseThrow(() -> new CustomException(CustomErrorCode.NO_RUSH_EVENT));
+
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime startDateTime = rushEvent.getStartDateTime();
+        LocalDateTime endDateTime = rushEvent.getEndDateTime();
+
+        if(now.isAfter(startDateTime) && now.isBefore(endDateTime))
+            throw new CustomException(CustomErrorCode.EVENT_IN_PROGRESS_CANNOT_DELETE);
+        rushEventRepository.delete(rushEvent);
+        return ResponseDto.of("요청에 성공하였습니다.");
+    }
+
     public List<LotteryEventExpectationResponseDto> getLotteryEventExpectations(Long participantId) {
         LotteryParticipants lotteryParticipant = lotteryParticipantsRepository.findById(participantId).orElseThrow(
                 () -> new CustomException(CustomErrorCode.USER_NOT_FOUND)

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/EventService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/EventService.java
@@ -1,0 +1,46 @@
+package JGS.CasperEvent.domain.event.service.eventService;
+
+import JGS.CasperEvent.domain.event.dto.ResponseDto.TotalEventDateResponseDto;
+import JGS.CasperEvent.domain.event.entity.event.LotteryEvent;
+import JGS.CasperEvent.domain.event.entity.event.RushEvent;
+import JGS.CasperEvent.domain.event.repository.eventRepository.LotteryEventRepository;
+import JGS.CasperEvent.domain.event.repository.eventRepository.RushEventRepository;
+import JGS.CasperEvent.global.enums.CustomErrorCode;
+import JGS.CasperEvent.global.error.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class EventService {
+    private final RushEventRepository rushEventRepository;
+    private final LotteryEventRepository lotteryEventRepository;
+
+    public TotalEventDateResponseDto getTotalEventDate() {
+        List<LotteryEvent> lotteryEventList = lotteryEventRepository.findAll();
+        List<RushEvent> rushEventList = rushEventRepository.findAll();
+
+        if (lotteryEventList.isEmpty()) {
+            throw new CustomException("추첨 이벤트가 DB에 존재하지 않습니다.", CustomErrorCode.NO_LOTTERY_EVENT);
+        }
+
+        List<LocalDate> localDateList = new ArrayList<>();
+
+        // lotteryEvent는 어차피 최대 1개만 존재
+        localDateList.add(lotteryEventList.get(0).getStartDateTime().toLocalDate());
+        localDateList.add(lotteryEventList.get(0).getEndDateTime().toLocalDate());
+
+        for (RushEvent rushEvent : rushEventList) {
+            localDateList.add(rushEvent.getStartDateTime().toLocalDate());
+        }
+
+        localDateList.sort(null);
+
+        return new TotalEventDateResponseDto(localDateList.get(0), localDateList.get(localDateList.size() - 1));
+    }
+}
+

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/LotteryEventService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/LotteryEventService.java
@@ -1,6 +1,6 @@
 package JGS.CasperEvent.domain.event.service.eventService;
 
-import JGS.CasperEvent.domain.event.dto.RequestDto.CasperBotRequestDto;
+import JGS.CasperEvent.domain.event.dto.RequestDto.lotteryEventDto.CasperBotRequestDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.CasperBotResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryParticipantResponseDto;

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/LotteryEventService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/LotteryEventService.java
@@ -47,17 +47,7 @@ public class LotteryEventService {
     public CasperBotResponseDto postCasperBot(BaseUser user, CasperBotRequestDto casperBotRequestDto) throws CustomException, NoSuchPaddingException, IllegalBlockSizeException, NoSuchAlgorithmException, BadPaddingException, InvalidKeyException {
         LotteryParticipants participants = registerUserIfNeed(user, casperBotRequestDto);
 
-        List<LotteryEvent> lotteryEventList = lotteryEventRepository.findAll();
-
-        if (lotteryEventList.isEmpty()) {
-            throw new CustomException("현재 진행중인 lotteryEvent가 존재하지 않습니다.", CustomErrorCode.NO_LOTTERY_EVENT);
-        }
-
-        if (lotteryEventList.size() > 1) {
-            throw new CustomException("현재 진행중인 lotteryEvent가 2개 이상입니다.", CustomErrorCode.TOO_MANY_LOTTERY_EVENT);
-        }
-
-        LotteryEvent lotteryEvent = lotteryEventList.get(0);
+        LotteryEvent lotteryEvent = getEvent();
 
         CasperBot casperBot = casperBotRepository.save(new CasperBot(casperBotRequestDto, user.getId()));
         lotteryEvent.addAppliedCount();
@@ -112,6 +102,11 @@ public class LotteryEventService {
     }
 
     public LotteryEventResponseDto getLotteryEvent() {
+        LotteryEvent lotteryEvent = getEvent();
+        return LotteryEventResponseDto.of(lotteryEvent, LocalDateTime.now());
+    }
+
+    private LotteryEvent getEvent() {
         List<LotteryEvent> lotteryEventList = lotteryEventRepository.findAll();
 
         if (lotteryEventList.isEmpty()) {
@@ -122,7 +117,6 @@ public class LotteryEventService {
             throw new CustomException("현재 진행중인 lotteryEvent가 2개 이상입니다.", CustomErrorCode.TOO_MANY_LOTTERY_EVENT);
         }
 
-        LotteryEvent lotteryEvent = lotteryEventList.get(0);
-        return LotteryEventResponseDto.of(lotteryEvent, LocalDateTime.now());
+        return lotteryEventList.get(0);
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/LotteryEventService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/LotteryEventService.java
@@ -86,7 +86,7 @@ public class LotteryEventService {
             lotteryParticipantsRepository.save(participant);
         }
 
-        if (!casperBotRequestDto.getReferralId().isEmpty()) {
+        if (casperBotRequestDto.getReferralId() != null) {
             String referralId = AESUtils.decrypt(casperBotRequestDto.getReferralId(), secretKey);
             Optional<LotteryParticipants> referralParticipant =
                     lotteryParticipantsRepository.findByBaseUser(

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/LotteryEventService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/LotteryEventService.java
@@ -29,6 +29,7 @@ import java.nio.file.attribute.UserPrincipalNotFoundException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -45,7 +46,18 @@ public class LotteryEventService {
 
     public CasperBotResponseDto postCasperBot(BaseUser user, CasperBotRequestDto casperBotRequestDto) throws CustomException, NoSuchPaddingException, IllegalBlockSizeException, NoSuchAlgorithmException, BadPaddingException, InvalidKeyException {
         LotteryParticipants participants = registerUserIfNeed(user, casperBotRequestDto);
-        LotteryEvent lotteryEvent = lotteryEventRepository.findById(1L).orElseThrow(LotteryEventNotExists::new);
+
+        List<LotteryEvent> lotteryEventList = lotteryEventRepository.findAll();
+
+        if (lotteryEventList.isEmpty()) {
+            throw new CustomException("현재 진행중인 lotteryEvent가 존재하지 않습니다.", CustomErrorCode.NO_LOTTERY_EVENT);
+        }
+
+        if (lotteryEventList.size() > 1) {
+            throw new CustomException("현재 진행중인 lotteryEvent가 2개 이상입니다.", CustomErrorCode.TOO_MANY_LOTTERY_EVENT);
+        }
+
+        LotteryEvent lotteryEvent = lotteryEventList.get(0);
 
         CasperBot casperBot = casperBotRepository.save(new CasperBot(casperBotRequestDto, user.getId()));
         lotteryEvent.addAppliedCount();
@@ -100,8 +112,17 @@ public class LotteryEventService {
     }
 
     public LotteryEventResponseDto getLotteryEvent() {
-        LotteryEvent lotteryEvent = lotteryEventRepository.findById(1L).orElseThrow(LotteryEventNotExists::new);
+        List<LotteryEvent> lotteryEventList = lotteryEventRepository.findAll();
+
+        if (lotteryEventList.isEmpty()) {
+            throw new CustomException("현재 진행중인 lotteryEvent가 존재하지 않습니다.", CustomErrorCode.NO_LOTTERY_EVENT);
+        }
+
+        if (lotteryEventList.size() > 1) {
+            throw new CustomException("현재 진행중인 lotteryEvent가 2개 이상입니다.", CustomErrorCode.TOO_MANY_LOTTERY_EVENT);
+        }
+
+        LotteryEvent lotteryEvent = lotteryEventList.get(0);
         return LotteryEventResponseDto.of(lotteryEvent, LocalDateTime.now());
     }
-
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/LotteryEventService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/LotteryEventService.java
@@ -1,9 +1,9 @@
 package JGS.CasperEvent.domain.event.service.eventService;
 
 import JGS.CasperEvent.domain.event.dto.RequestDto.CasperBotRequestDto;
-import JGS.CasperEvent.domain.event.dto.ResponseDto.CasperBotResponseDto;
-import JGS.CasperEvent.domain.event.dto.ResponseDto.LotteryEventResponseDto;
-import JGS.CasperEvent.domain.event.dto.ResponseDto.LotteryParticipantResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.CasperBotResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryParticipantResponseDto;
 import JGS.CasperEvent.domain.event.entity.casperBot.CasperBot;
 import JGS.CasperEvent.domain.event.entity.event.LotteryEvent;
 import JGS.CasperEvent.domain.event.entity.participants.LotteryParticipants;

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/RushEventScheduler.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/RushEventScheduler.java
@@ -1,5 +1,6 @@
 package JGS.CasperEvent.domain.event.service.eventService;
 
+import JGS.CasperEvent.domain.event.dto.ResponseDto.RushEventResponseDto;
 import JGS.CasperEvent.domain.event.entity.event.RushEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -15,7 +16,7 @@ import java.time.LocalDate;
 public class RushEventScheduler {
 
     private final RushEventService rushEventService;
-    private final RedisTemplate<String, RushEvent> rushEventRedisTemplate;
+    private final RedisTemplate<String, RushEventResponseDto> rushEventRedisTemplate;
 
     // 매일 12시에 스케줄된 작업을 실행합니다.
     @Scheduled(cron = "0 0 12 * * ?")
@@ -24,7 +25,7 @@ public class RushEventScheduler {
         LocalDate today = LocalDate.now();
 
         // EventService를 통해 오늘의 이벤트를 가져옵니다.
-        RushEvent todayEvent = rushEventService.getTodayRushEvent(today);
+        RushEventResponseDto todayEvent = rushEventService.getTodayRushEvent(today);
 
         // 가져온 이벤트에 대한 추가 작업을 수행합니다.
         // 예: 캐싱, 로그 기록, 알림 발송 등

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/RushEventScheduler.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/RushEventScheduler.java
@@ -1,7 +1,6 @@
 package JGS.CasperEvent.domain.event.service.eventService;
 
-import JGS.CasperEvent.domain.event.dto.ResponseDto.RushEventResponseDto;
-import JGS.CasperEvent.domain.event.entity.event.RushEvent;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.RushEventResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.EnableScheduling;

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/RushEventService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/RushEventService.java
@@ -35,12 +35,7 @@ public class RushEventService {
     @Transactional
     public RushEventListResponseDto getAllRushEvents() {
         // 오늘의 선착순 이벤트 꺼내오기
-        RushEventResponseDto todayEvent = rushEventRedisTemplate.opsForValue().get("todayEvent");
-
-        // 오늘의 선착순 이벤트가 redis에 등록되지 않은 경우
-        if (todayEvent == null) {
-            throw new CustomException("오늘의 선착순 이벤트가 redis에 등록되지 않았습니다.", CustomErrorCode.TODAY_RUSH_EVENT_NOT_FOUND);
-        }
+        RushEventResponseDto todayEvent = getTodayRushEvent();
 
         // DB에서 모든 RushEvent 가져오기
         List<RushEvent> rushEventList = rushEventRepository.findAll();
@@ -161,7 +156,7 @@ public class RushEventService {
         }
 
         if (rushEventList.size() > 1) {
-            throw new CustomException("선착순 이벤트가 존재하지않습니다.", CustomErrorCode.MULTIPLE_RUSH_EVENTS_FOUND);
+            throw new CustomException("선착순 이벤트가 2개 이상 존재합니다.", CustomErrorCode.MULTIPLE_RUSH_EVENTS_FOUND);
         }
 
         return RushEventResponseDto.of(rushEventList.get(0));
@@ -237,15 +232,10 @@ public class RushEventService {
         rushEventRedisTemplate.opsForValue().set("todayEvent", RushEventResponseDto.of(rushEvents.get(2)));
     }
 
-
     // 오늘의 이벤트 옵션 정보를 반환
     public MainRushEventOptionsResponseDto getTodayRushEventOptions() {
         RushEventResponseDto todayEvent = getTodayRushEvent();
         Set<RushEventOptionResponseDto> options = todayEvent.options();
-
-        if (options.size() != 2) {
-            throw new CustomException("해당 이벤트의 선택지가 2개가 아닙니다.", CustomErrorCode.INVALID_RUSH_EVENT_OPTIONS_COUNT);
-        }
 
         RushEventOptionResponseDto leftOption = options.stream()
                 .filter(option -> option.position() == Position.LEFT)

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/RushEventService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/RushEventService.java
@@ -1,6 +1,6 @@
 package JGS.CasperEvent.domain.event.service.eventService;
 
-import JGS.CasperEvent.domain.event.dto.ResponseDto.*;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.*;
 import JGS.CasperEvent.domain.event.entity.event.RushEvent;
 import JGS.CasperEvent.domain.event.entity.event.RushOption;
 import JGS.CasperEvent.domain.event.entity.participants.RushParticipants;

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/RushEventService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/RushEventService.java
@@ -174,7 +174,7 @@ public class RushEventService {
             RushEvent rushEvent = new RushEvent(
                     startDateTime.plusDays(i),  // 이벤트 시작 날짜
                     endDateTime.plusDays(i),    // 이벤트 종료 날짜
-                    0,                          // 우승자 수 (winnerCount)
+                    315,                          // 우승자 수 (winnerCount)
                     "http://example.com/prize" + (i + 1) + ".jpg",  // 상 이미지 URL
                     "Prize Description " + (i + 1)                  // 상 설명
             );

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/RushEventService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/RushEventService.java
@@ -163,7 +163,8 @@ public class RushEventService {
         rushOptionRepository.deleteAllInBatch();
         rushEventRepository.deleteAllInBatch();
 
-        LocalDateTime startDateTime = LocalDateTime.of(2024, 8, 11, 22, 0);
+        // 현재 날짜와 시간을 기준으로 이벤트 시간 설정
+        LocalDateTime startDateTime = LocalDateTime.now().withHour(22).withMinute(0).withSecond(0).withNano(0);
         LocalDateTime endDateTime = startDateTime.plusMinutes(10);
 
         List<RushEvent> rushEvents = new ArrayList<>();

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/RushEventService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/RushEventService.java
@@ -163,14 +163,14 @@ public class RushEventService {
         rushOptionRepository.deleteAllInBatch();
         rushEventRepository.deleteAllInBatch();
 
-        // 현재 날짜와 시간을 기준으로 이벤트 시간 설정
-        LocalDateTime startDateTime = LocalDateTime.now().withHour(22).withMinute(0).withSecond(0).withNano(0);
+        // 오늘의 날짜를 기준으로 시간 설정
+        LocalDateTime startDateTime = LocalDateTime.now().minusDays(2).withHour(22).withMinute(0).withSecond(0).withNano(0);
         LocalDateTime endDateTime = startDateTime.plusMinutes(10);
 
         List<RushEvent> rushEvents = new ArrayList<>();
 
         for (int i = 0; i < 6; i++) {
-            // RushEvent 생성 및 초기화
+            // 각 이벤트의 날짜를 오늘 기준으로 설정
             RushEvent rushEvent = new RushEvent(
                     startDateTime.plusDays(i),  // 이벤트 시작 날짜
                     endDateTime.plusDays(i),    // 이벤트 종료 날짜
@@ -212,9 +212,10 @@ public class RushEventService {
             rushEvents.add(rushEvent);
         }
 
-        // 처음으로 생성된 RushEvent를 Redis에 저장
-        rushEventRedisTemplate.opsForValue().set("todayEvent", RushEventResponseDto.of(rushEvents.get(0)));
+        // 세 번째로 생성된 RushEvent를 Redis에 저장
+        rushEventRedisTemplate.opsForValue().set("todayEvent", RushEventResponseDto.of(rushEvents.get(2)));
     }
+
 
     // 오늘의 이벤트 옵션 정보를 반환
     public MainRushEventOptionsResponseDto getTodayRushEventOptions() {

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/redisService/RedisService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/redisService/RedisService.java
@@ -1,6 +1,6 @@
 package JGS.CasperEvent.domain.event.service.redisService;
 
-import JGS.CasperEvent.domain.event.dto.ResponseDto.CasperBotResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.CasperBotResponseDto;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;

--- a/Server/src/main/java/JGS/CasperEvent/global/config/LocalS3Config.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/config/LocalS3Config.java
@@ -1,0 +1,35 @@
+package JGS.CasperEvent.global.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile("local")
+public class LocalS3Config {
+    @Value("${spring.cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${spring.cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${spring.cloud.aws.s3.region}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3(){
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    }
+}

--- a/Server/src/main/java/JGS/CasperEvent/global/config/RedisConfig.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/config/RedisConfig.java
@@ -1,7 +1,7 @@
 package JGS.CasperEvent.global.config;
 
-import JGS.CasperEvent.domain.event.dto.ResponseDto.CasperBotResponseDto;
-import JGS.CasperEvent.domain.event.dto.ResponseDto.RushEventResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.CasperBotResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.RushEventResponseDto;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;

--- a/Server/src/main/java/JGS/CasperEvent/global/config/RedisConfig.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/config/RedisConfig.java
@@ -1,7 +1,7 @@
 package JGS.CasperEvent.global.config;
 
 import JGS.CasperEvent.domain.event.dto.ResponseDto.CasperBotResponseDto;
-import JGS.CasperEvent.domain.event.entity.event.RushEvent;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.RushEventResponseDto;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -39,8 +39,8 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, RushEvent> RushEventRedisTemplate(){
-        RedisTemplate<String, RushEvent> redisTemplate = new RedisTemplate<>();
+    public RedisTemplate<String, RushEventResponseDto> RushEventRedisTemplate(){
+        RedisTemplate<String, RushEventResponseDto> redisTemplate = new RedisTemplate<>();
         redisTemplate.setConnectionFactory(redisConnectionFactory());
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());

--- a/Server/src/main/java/JGS/CasperEvent/global/config/S3Config.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/config/S3Config.java
@@ -1,0 +1,33 @@
+package JGS.CasperEvent.global.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${spring.cloud.aws.credentials.accessKey}")
+    private String accessKey;
+
+    @Value("${spring.cloud.aws.credentials.secretKey}")
+    private String secretKey;
+
+    @Value("${spring.cloud.aws.s3.region}")
+    private String region;
+
+    @Bean
+    public AmazonS3 amazonS3(){
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return AmazonS3ClientBuilder
+                .standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region)
+                .build();
+    };
+}

--- a/Server/src/main/java/JGS/CasperEvent/global/config/S3Config.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/config/S3Config.java
@@ -2,6 +2,7 @@ package JGS.CasperEvent.global.config;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -9,8 +10,12 @@ import org.springframework.context.annotation.Profile;
 @Configuration
 @Profile("prod")
 public class S3Config {
+    @Value("${spring.cloud.aws.s3.region}")
+    private String region;
     @Bean
     public AmazonS3 amazonS3(){
-        return AmazonS3ClientBuilder.defaultClient();
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .build();
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/global/config/S3Config.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/config/S3Config.java
@@ -29,5 +29,5 @@ public class S3Config {
                 .withCredentials(new AWSStaticCredentialsProvider(credentials))
                 .withRegion(region)
                 .build();
-    };
+    }
 }

--- a/Server/src/main/java/JGS/CasperEvent/global/config/S3Config.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/config/S3Config.java
@@ -1,33 +1,16 @@
 package JGS.CasperEvent.global.config;
 
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 
 @Configuration
+@Profile("prod")
 public class S3Config {
-    @Value("${spring.cloud.aws.credentials.accessKey}")
-    private String accessKey;
-
-    @Value("${spring.cloud.aws.credentials.secretKey}")
-    private String secretKey;
-
-    @Value("${spring.cloud.aws.s3.region}")
-    private String region;
-
     @Bean
     public AmazonS3 amazonS3(){
-        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
-
-        return AmazonS3ClientBuilder
-                .standard()
-                .withCredentials(new AWSStaticCredentialsProvider(credentials))
-                .withRegion(region)
-                .build();
+        return AmazonS3ClientBuilder.defaultClient();
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/global/config/WebConfig.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/config/WebConfig.java
@@ -37,6 +37,7 @@ public class WebConfig implements WebMvcConfigurer {
         config.setAllowCredentials(true);
         config.addAllowedOrigin("http://localhost:5173");
         config.addAllowedOrigin("https://d3phfzvzx3wm4l.cloudfront.net/");
+        config.addAllowedOrigin("https://d2oxrno1u2ah9j.cloudfront.net/");
         config.addAllowedOrigin("https://hybrid-jgs.shop");
         config.addAllowedHeader("*");
         config.addAllowedMethod("*");

--- a/Server/src/main/java/JGS/CasperEvent/global/config/WebConfig.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/config/WebConfig.java
@@ -22,15 +22,6 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
-//    @Override
-//    public void addCorsMappings(CorsRegistry registration) {
-//        registration.addMapping("/**")
-//                .allowCredentials(true)
-//                .allowedOrigins("http://localhost:5173", "https://d3phfzvzx3wm4l.cloudfront.net/")
-//                .allowedMethods("GET", "POST", "PUT", "DELETE")
-//                .allowedHeaders("*");
-//    }
-
     @Bean
     public FilterRegistrationBean<CorsFilter> corsFilterRegistrationBean() {
         FilterRegistrationBean<CorsFilter> registrationBean = new FilterRegistrationBean<>();

--- a/Server/src/main/java/JGS/CasperEvent/global/entity/BaseUser.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/entity/BaseUser.java
@@ -5,10 +5,12 @@ import JGS.CasperEvent.domain.event.entity.participants.RushParticipants;
 import JGS.CasperEvent.global.enums.Role;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
 @Entity
+@EqualsAndHashCode(callSuper = false)
 @Inheritance(strategy = InheritanceType.JOINED)
 public class BaseUser extends BaseEntity {
     @Id

--- a/Server/src/main/java/JGS/CasperEvent/global/enums/CustomErrorCode.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/enums/CustomErrorCode.java
@@ -18,6 +18,7 @@ public enum CustomErrorCode {
     JWT_MISSING("인증 토큰이 존재하지 않습니다.", 401),
     MULTIPLE_RUSH_EVENTS_FOUND("해당 날짜에 여러 개의 이벤트가 존재합니다.", 409),
     TODAY_RUSH_EVENT_NOT_FOUND("오늘의 이벤트를 찾을 수 없습니다.", 404),
+    LOTTERY_EVENT_ALREADY_EXISTS("추첨 이벤트가 이미 존재합니다.", 409),
     INVALID_RUSH_EVENT_OPTIONS_COUNT("이벤트의 옵션 수가 올바르지 않습니다.", 500),
     INVALID_RUSH_EVENT_OPTION_ID("옵션 ID는 1 또는 2여야 합니다.", 400);
 

--- a/Server/src/main/java/JGS/CasperEvent/global/enums/CustomErrorCode.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/enums/CustomErrorCode.java
@@ -22,7 +22,8 @@ public enum CustomErrorCode {
     LOTTERY_EVENT_ALREADY_EXISTS("추첨 이벤트가 이미 존재합니다.", 409),
     INVALID_RUSH_EVENT_OPTIONS_COUNT("이벤트의 옵션 수가 올바르지 않습니다.", 500),
     INVALID_RUSH_EVENT_OPTION_ID("옵션 ID는 1 또는 2여야 합니다.", 400),
-    EMPTY_FILE("유효하지 않은 파일입니다.", 422);
+    EMPTY_FILE("유효하지 않은 파일입니다.", 422),
+    TOO_MANY_LOTTERY_EVENT("현재 진행중인 추첨 이벤트가 2개 이상입니다.", 409);
 
     private final String message;
     private int status;

--- a/Server/src/main/java/JGS/CasperEvent/global/enums/CustomErrorCode.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/enums/CustomErrorCode.java
@@ -28,7 +28,8 @@ public enum CustomErrorCode {
     EVENT_IN_PROGRESS_END_TIME_BEFORE_NOW("현재 진행 중인 이벤트의 종료 시간을 현재 시간보다 이전으로 설정할 수 없습니다.", 400),
     EVENT_BEFORE_START_TIME("이벤트 시작 시간은 현재 시간 이후로 설정해야 합니다.", 400),
     EVENT_END_TIME_BEFORE_START_TIME("종료 시간은 시작 시간 이후로 설정해야 합니다.", 400),
-    INVALID_RUSH_EVENT_OPTION("밸런스 게임 선택지가 유효하지 않습니다.");
+    INVALID_RUSH_EVENT_OPTION("밸런스 게임 선택지가 유효하지 않습니다."),
+    EVENT_IN_PROGRESS_CANNOT_DELETE("진행중인 이벤트를 삭제할 수 없습니다.", 409);
 
 
 

--- a/Server/src/main/java/JGS/CasperEvent/global/enums/CustomErrorCode.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/enums/CustomErrorCode.java
@@ -29,7 +29,8 @@ public enum CustomErrorCode {
     EVENT_BEFORE_START_TIME("이벤트 시작 시간은 현재 시간 이후로 설정해야 합니다.", 400),
     EVENT_END_TIME_BEFORE_START_TIME("종료 시간은 시작 시간 이후로 설정해야 합니다.", 400),
     INVALID_RUSH_EVENT_OPTION("밸런스 게임 선택지가 유효하지 않습니다."),
-    EVENT_IN_PROGRESS_CANNOT_DELETE("진행중인 이벤트를 삭제할 수 없습니다.", 409);
+    EVENT_IN_PROGRESS_CANNOT_DELETE("진행중인 이벤트를 삭제할 수 없습니다.", 409),
+    LOTTERY_EVENT_ALREADY_DRAWN("추첨 이벤트의 당첨자가 이미 추첨되었습니다.", 409),;
 
 
 

--- a/Server/src/main/java/JGS/CasperEvent/global/enums/CustomErrorCode.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/enums/CustomErrorCode.java
@@ -27,7 +27,9 @@ public enum CustomErrorCode {
     EVENT_IN_PROGRESS_CANNOT_CHANGE_START_TIME("현재 진행 중인 이벤트의 시작 시간을 변경할 수 없습니다.", 400),
     EVENT_IN_PROGRESS_END_TIME_BEFORE_NOW("현재 진행 중인 이벤트의 종료 시간을 현재 시간보다 이전으로 설정할 수 없습니다.", 400),
     EVENT_BEFORE_START_TIME("이벤트 시작 시간은 현재 시간 이후로 설정해야 합니다.", 400),
-    EVENT_END_TIME_BEFORE_START_TIME("종료 시간은 시작 시간 이후로 설정해야 합니다.", 400);
+    EVENT_END_TIME_BEFORE_START_TIME("종료 시간은 시작 시간 이후로 설정해야 합니다.", 400),
+    INVALID_RUSH_EVENT_OPTION("밸런스 게임 선택지가 유효하지 않습니다.");
+
 
 
     private final String message;

--- a/Server/src/main/java/JGS/CasperEvent/global/enums/CustomErrorCode.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/enums/CustomErrorCode.java
@@ -21,7 +21,8 @@ public enum CustomErrorCode {
     TODAY_RUSH_EVENT_NOT_FOUND("오늘의 이벤트를 찾을 수 없습니다.", 404),
     LOTTERY_EVENT_ALREADY_EXISTS("추첨 이벤트가 이미 존재합니다.", 409),
     INVALID_RUSH_EVENT_OPTIONS_COUNT("이벤트의 옵션 수가 올바르지 않습니다.", 500),
-    INVALID_RUSH_EVENT_OPTION_ID("옵션 ID는 1 또는 2여야 합니다.", 400);
+    INVALID_RUSH_EVENT_OPTION_ID("옵션 ID는 1 또는 2여야 합니다.", 400),
+    EMPTY_FILE("유효하지 않은 파일입니다.", 422);
 
     private final String message;
     private int status;

--- a/Server/src/main/java/JGS/CasperEvent/global/enums/CustomErrorCode.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/enums/CustomErrorCode.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 @Getter
 public enum CustomErrorCode {
     NO_RUSH_EVENT("선착순 이벤트를 찾을 수 없습니다.", 404),
+    NO_RUSH_EVENT_OPTION("해당 밸런스 게임 선택지를 찾을 수 없습니다.", 404),
     INVALID_PARAMETER("잘못된 파라미터 입력입니다.", 400),
     CASPERBOT_NOT_FOUND("배지를 찾을 수 없습니다.", 404),
     BAD_REQUEST("잘못된 요청입니다.", 400),
@@ -16,7 +17,9 @@ public enum CustomErrorCode {
     JWT_EXPIRED("만료된 토큰입니다.", 400),
     JWT_MISSING("인증 토큰이 존재하지 않습니다.", 401),
     MULTIPLE_RUSH_EVENTS_FOUND("해당 날짜에 여러 개의 이벤트가 존재합니다.", 409),
-    TODAY_RUSH_EVENT_NOT_FOUND("오늘의 이벤트를 찾을 수 없습니다.", 404);  // 새로운 예외 추가
+    TODAY_RUSH_EVENT_NOT_FOUND("오늘의 이벤트를 찾을 수 없습니다.", 404),
+    INVALID_RUSH_EVENT_OPTIONS_COUNT("이벤트의 옵션 수가 올바르지 않습니다.", 500),
+    INVALID_RUSH_EVENT_OPTION_ID("옵션 ID는 1 또는 2여야 합니다.", 400);
 
     private final String message;
     private int status;

--- a/Server/src/main/java/JGS/CasperEvent/global/enums/CustomErrorCode.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/enums/CustomErrorCode.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 @Getter
 public enum CustomErrorCode {
     NO_RUSH_EVENT("선착순 이벤트를 찾을 수 없습니다.", 404),
+    NO_LOTTERY_EVENT("선착순 이벤트를 찾을 수 없습니다.", 404),
     NO_RUSH_EVENT_OPTION("해당 밸런스 게임 선택지를 찾을 수 없습니다.", 404),
     INVALID_PARAMETER("잘못된 파라미터 입력입니다.", 400),
     CASPERBOT_NOT_FOUND("배지를 찾을 수 없습니다.", 404),

--- a/Server/src/main/java/JGS/CasperEvent/global/enums/CustomErrorCode.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/enums/CustomErrorCode.java
@@ -30,7 +30,9 @@ public enum CustomErrorCode {
     EVENT_END_TIME_BEFORE_START_TIME("종료 시간은 시작 시간 이후로 설정해야 합니다.", 400),
     INVALID_RUSH_EVENT_OPTION("밸런스 게임 선택지가 유효하지 않습니다."),
     EVENT_IN_PROGRESS_CANNOT_DELETE("진행중인 이벤트를 삭제할 수 없습니다.", 409),
-    LOTTERY_EVENT_ALREADY_DRAWN("추첨 이벤트의 당첨자가 이미 추첨되었습니다.", 409),;
+    LOTTERY_EVENT_ALREADY_DRAWN("추첨 이벤트의 당첨자가 이미 추첨되었습니다.", 409),
+    LOTTERY_EVENT_NOT_DRAWN("추첨 이벤트가 아직 추첨되지 않았습니다.", 404);
+
 
 
 

--- a/Server/src/main/java/JGS/CasperEvent/global/enums/CustomErrorCode.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/enums/CustomErrorCode.java
@@ -23,7 +23,12 @@ public enum CustomErrorCode {
     INVALID_RUSH_EVENT_OPTIONS_COUNT("이벤트의 옵션 수가 올바르지 않습니다.", 500),
     INVALID_RUSH_EVENT_OPTION_ID("옵션 ID는 1 또는 2여야 합니다.", 400),
     EMPTY_FILE("유효하지 않은 파일입니다.", 422),
-    TOO_MANY_LOTTERY_EVENT("현재 진행중인 추첨 이벤트가 2개 이상입니다.", 409);
+    TOO_MANY_LOTTERY_EVENT("현재 진행중인 추첨 이벤트가 2개 이상입니다.", 409),
+    EVENT_IN_PROGRESS_CANNOT_CHANGE_START_TIME("현재 진행 중인 이벤트의 시작 시간을 변경할 수 없습니다.", 400),
+    EVENT_IN_PROGRESS_END_TIME_BEFORE_NOW("현재 진행 중인 이벤트의 종료 시간을 현재 시간보다 이전으로 설정할 수 없습니다.", 400),
+    EVENT_BEFORE_START_TIME("이벤트 시작 시간은 현재 시간 이후로 설정해야 합니다.", 400),
+    EVENT_END_TIME_BEFORE_START_TIME("종료 시간은 시작 시간 이후로 설정해야 합니다.", 400);
+
 
     private final String message;
     private int status;

--- a/Server/src/main/java/JGS/CasperEvent/global/enums/EventStatus.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/enums/EventStatus.java
@@ -1,0 +1,16 @@
+package JGS.CasperEvent.global.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum EventStatus {
+    BEFORE(1),
+    DURING(2),
+    AFTER(3);
+
+    private final int eventStatus;
+
+    EventStatus(int eventStatus){
+        this.eventStatus = eventStatus;
+    }
+}

--- a/Server/src/main/java/JGS/CasperEvent/global/enums/Position.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/enums/Position.java
@@ -1,0 +1,26 @@
+package JGS.CasperEvent.global.enums;
+
+import JGS.CasperEvent.global.error.exception.CustomException;
+import lombok.Getter;
+
+@Getter
+public enum Position {
+    LEFT(1),
+    RIGHT(2);
+
+    private final int position;
+
+    Position(int position) {
+        this.position = position;
+    }
+
+    public static Position of(int position) {
+        for (Position pos : Position.values()) {
+            if (pos.getPosition() == position) {
+                return pos;
+            }
+        }
+
+        throw new CustomException("optionId는 1 또는 2여야 합니다.", CustomErrorCode.INVALID_RUSH_EVENT_OPTION_ID);
+    }
+}

--- a/Server/src/main/java/JGS/CasperEvent/global/error/GlobalExceptionHandler.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/error/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package JGS.CasperEvent.global.error;
 
 import JGS.CasperEvent.global.enums.CustomErrorCode;
 import JGS.CasperEvent.global.error.exception.CustomException;
+import JGS.CasperEvent.global.error.exception.TooManyLotteryEventException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
@@ -33,8 +34,15 @@ public class GlobalExceptionHandler  {
     @ExceptionHandler(UserPrincipalNotFoundException.class)
     public ResponseEntity<ErrorResponse> userPrincipalNotFoundHandler(){
         return ResponseEntity
-                .status(HttpStatus.NOT_FOUND)
+                .status(HttpStatus.CONFLICT)
                 .body(ErrorResponse.of(CustomErrorCode.USER_NOT_FOUND));
+    }
+
+    @ExceptionHandler(TooManyLotteryEventException.class)
+    public ResponseEntity<ErrorResponse> tooManyLotteryEventExceptionHandler(){
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(ErrorResponse.of(CustomErrorCode.LOTTERY_EVENT_ALREADY_EXISTS));
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)

--- a/Server/src/main/java/JGS/CasperEvent/global/error/exception/CustomException.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/error/exception/CustomException.java
@@ -1,7 +1,9 @@
 package JGS.CasperEvent.global.error.exception;
 
 import JGS.CasperEvent.global.enums.CustomErrorCode;
+import lombok.Getter;
 
+@Getter
 public class CustomException extends RuntimeException {
     private final CustomErrorCode errorCode;
 
@@ -10,7 +12,9 @@ public class CustomException extends RuntimeException {
         this.errorCode = errorCode;
     }
 
-    public CustomErrorCode getErrorCode() {
-        return errorCode;
+    public CustomException(CustomErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
     }
+
 }

--- a/Server/src/main/java/JGS/CasperEvent/global/error/exception/LotteryEventNotExists.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/error/exception/LotteryEventNotExists.java
@@ -1,0 +1,4 @@
+package JGS.CasperEvent.global.error.exception;
+
+public class LotteryEventNotExists extends RuntimeException{
+}

--- a/Server/src/main/java/JGS/CasperEvent/global/error/exception/TooManyLotteryEventException.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/error/exception/TooManyLotteryEventException.java
@@ -1,0 +1,5 @@
+package JGS.CasperEvent.global.error.exception;
+
+public class TooManyLotteryEventException extends RuntimeException {
+    
+}

--- a/Server/src/main/java/JGS/CasperEvent/global/error/exception/TooManyRushEventException.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/error/exception/TooManyRushEventException.java
@@ -1,0 +1,4 @@
+package JGS.CasperEvent.global.error.exception;
+
+public class TooManyRushEventException extends RuntimeException{
+}

--- a/Server/src/main/java/JGS/CasperEvent/global/jwt/dto/UserLoginDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/jwt/dto/UserLoginDto.java
@@ -1,8 +1,14 @@
 package JGS.CasperEvent.global.jwt.dto;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class UserLoginDto {
     String phoneNumber;
+
+    public UserLoginDto(String phoneNumber) {
+        this.phoneNumber = phoneNumber;
+    }
 }

--- a/Server/src/main/java/JGS/CasperEvent/global/jwt/filter/JwtAdminFilter.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/jwt/filter/JwtAdminFilter.java
@@ -29,8 +29,5 @@ public class JwtAdminFilter implements Filter {
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
         response.getWriter().write(json);
-
-//        HttpServletResponse httpServletResponse = (HttpServletResponse) response;
-//        httpServletResponse.sendError(HttpStatus.BAD_REQUEST.value());
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/global/jwt/filter/JwtAuthorizationFilter.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/jwt/filter/JwtAuthorizationFilter.java
@@ -32,7 +32,7 @@ public class JwtAuthorizationFilter implements Filter {
             "/event/rush", "/event/lottery/caspers",
             "/admin/join", "/admin/auth", "/h2", "/h2/*",
             "/swagger-ui/*", "/v3/api-docs", "/v3/api-docs/*",
-            "/event/lottery", "/link/*"
+            "/event/lottery", "/link/*", "/event/total"
     };
     private final String[] blackListUris = new String[]{
             "/event/rush/*", "/event/lottery/casperBot"

--- a/Server/src/main/java/JGS/CasperEvent/global/jwt/filter/JwtUserFilter.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/jwt/filter/JwtUserFilter.java
@@ -29,8 +29,5 @@ public class JwtUserFilter implements Filter {
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");
         response.getWriter().write(json);
-
-//        HttpServletResponse httpServletResponse = (HttpServletResponse) response;
-//        httpServletResponse.sendError(HttpStatus.BAD_REQUEST.value());
     }
 }

--- a/Server/src/main/java/JGS/CasperEvent/global/jwt/util/JwtProvider.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/jwt/util/JwtProvider.java
@@ -40,7 +40,7 @@ public class JwtProvider {
 
 
     private Date getExpireDateAccessToken() {
-        long expireTimeMils = 1000L * 60 * 5;
+        long expireTimeMils = 1000L * 60 * 60  * 24 * 365;
         return new Date(System.currentTimeMillis() + expireTimeMils);
     }
 

--- a/Server/src/main/java/JGS/CasperEvent/global/jwt/util/JwtProvider.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/jwt/util/JwtProvider.java
@@ -22,7 +22,7 @@ public class JwtProvider {
                 .build();
     }
 
-    public String createToken(Map<String, Object> claims, Date expireDate) {
+    private String createToken(Map<String, Object> claims, Date expireDate) {
         return Jwts.builder()
                 .setClaims(claims)
                 .setExpiration(expireDate)
@@ -39,7 +39,7 @@ public class JwtProvider {
     }
 
 
-    public Date getExpireDateAccessToken() {
+    private Date getExpireDateAccessToken() {
         long expireTimeMils = 1000L * 60 * 60 * 24 * 365;
         return new Date(System.currentTimeMillis() + expireTimeMils);
     }

--- a/Server/src/main/java/JGS/CasperEvent/global/jwt/util/JwtProvider.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/jwt/util/JwtProvider.java
@@ -40,7 +40,7 @@ public class JwtProvider {
 
 
     private Date getExpireDateAccessToken() {
-        long expireTimeMils = 1000L * 60 * 60 * 24 * 365;
+        long expireTimeMils = 1000L * 60 * 5;
         return new Date(System.currentTimeMillis() + expireTimeMils);
     }
 

--- a/Server/src/main/java/JGS/CasperEvent/global/service/S3Service.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/service/S3Service.java
@@ -5,7 +5,7 @@ import com.amazonaws.services.s3.model.*;
 import com.amazonaws.util.IOUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.ByteArrayInputStream;
@@ -21,7 +21,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 @RequiredArgsConstructor
-@Component
+@Service
 public class S3Service {
 
     private final AmazonS3 amazonS3;

--- a/Server/src/main/java/JGS/CasperEvent/global/service/S3Service.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/service/S3Service.java
@@ -1,0 +1,110 @@
+package JGS.CasperEvent.global.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.*;
+import com.amazonaws.util.IOUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLDecoder;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Component
+public class S3Service {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${spring.cloud.aws.s3.bucket}")
+    private String bucketName;
+
+    public String upload(MultipartFile image) {
+        if (image.isEmpty() || Objects.isNull(image.getOriginalFilename()))
+            throw new AmazonS3Exception("파일이 유효하지 않습니다.");
+        return this.uploadImage(image);
+    }
+
+    private String uploadImage(MultipartFile image) {
+        this.validateImageFileExtension(image.getOriginalFilename());
+        try {
+            return this.uploadImageToS3(image);
+        } catch (IOException e) {
+            throw new AmazonS3Exception("io exception on image upload");
+        }
+    }
+
+    private void validateImageFileExtension(String filename) {
+        int lastDotIndex = filename.lastIndexOf(".");
+        if (lastDotIndex == -1) {
+            throw new AmazonS3Exception("파일에 확장자가 존재하지 않습니다.");
+        }
+
+        String extension = filename.substring(lastDotIndex + 1).toLowerCase();
+        List<String> allowedExtentionList = Arrays.asList("jpg", "jpeg", "png", "gif");
+
+        if (!allowedExtentionList.contains(extension)) {
+            throw new AmazonS3Exception("유효하지 않은 확장자입니다.");
+        }
+    }
+
+    private String uploadImageToS3(MultipartFile image) throws IOException {
+        String originalFilename = image.getOriginalFilename(); //원본 파일 명
+        String extension = Objects.requireNonNull(originalFilename).substring(originalFilename.lastIndexOf(".") + 1); //확장자 명
+
+        String s3FileName = "image/" + UUID.randomUUID().toString().substring(0, 10) + originalFilename; //변경된 파일 명
+
+        InputStream is = image.getInputStream();
+        byte[] bytes = IOUtils.toByteArray(is);
+
+        ObjectMetadata metadata = new ObjectMetadata(); //metadata 생성
+        metadata.setContentType("image/" + extension);
+        metadata.setContentLength(bytes.length);
+
+        ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
+
+        try {
+            PutObjectRequest putObjectRequest =
+                    new PutObjectRequest(bucketName, s3FileName, byteArrayInputStream, metadata);
+//                            .withCannedAcl(CannedAccessControlList.PublicRead);
+            //실제로 S3에 이미지 데이터를 넣는 부분이다.
+            amazonS3.putObject(putObjectRequest); // put image to S3
+        } catch (Exception e) {
+            throw new AmazonS3Exception("이미지 업로드에 실패했습니다.");
+        } finally {
+            byteArrayInputStream.close();
+            is.close();
+        }
+
+        return amazonS3.getUrl(bucketName, s3FileName).toString();
+    }
+
+    public void deleteImageFromS3(String imageAddress) {
+        String key = getKeyFromImageAddress(imageAddress);
+        try {
+            amazonS3.deleteObject(new DeleteObjectRequest(bucketName, key));
+        } catch (Exception e) {
+            throw new AmazonS3Exception("이미지 삭제에 실패했습니다.");
+        }
+    }
+
+    private String getKeyFromImageAddress(String imageAddress) {
+        try {
+            URL url = new URL(imageAddress);
+            String decodingKey = URLDecoder.decode(url.getPath(), "UTF-8");
+            return decodingKey.substring(1); // 맨 앞의 '/' 제거
+        } catch (MalformedURLException | UnsupportedEncodingException e) {
+            throw new AmazonS3Exception("이미지 삭제에 실패했습니다.");
+        }
+    }
+}

--- a/Server/src/main/java/JGS/CasperEvent/global/util/AESUtils.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/util/AESUtils.java
@@ -17,15 +17,13 @@ public class AESUtils {
         Cipher cipher = Cipher.getInstance("AES");
         cipher.init(Cipher.ENCRYPT_MODE, key);
         byte[] encryptedBytes = cipher.doFinal(plainText.getBytes());
-        return Base62Utils.encode(encryptedBytes);
+        return Base64.getUrlEncoder().encodeToString(encryptedBytes);
     }
 
     public static String decrypt(String encryptedText, SecretKey key) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
         Cipher cipher = Cipher.getInstance("AES");
         cipher.init(Cipher.DECRYPT_MODE, key);
-        byte[] decryptedBytes = cipher.doFinal(Base62Utils.decodeToBytes(encryptedText));
+        byte[] decryptedBytes = cipher.doFinal(Base64.getUrlDecoder().decode(encryptedText));
         return new String(decryptedBytes);
     }
-
-
 }

--- a/Server/src/main/java/JGS/CasperEvent/global/util/AESUtils.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/util/AESUtils.java
@@ -17,13 +17,13 @@ public class AESUtils {
         Cipher cipher = Cipher.getInstance("AES");
         cipher.init(Cipher.ENCRYPT_MODE, key);
         byte[] encryptedBytes = cipher.doFinal(plainText.getBytes());
-        return Base64.getEncoder().encodeToString(encryptedBytes);
+        return Base62Utils.encode(encryptedBytes);
     }
 
     public static String decrypt(String encryptedText, SecretKey key) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException, IllegalBlockSizeException, BadPaddingException {
         Cipher cipher = Cipher.getInstance("AES");
         cipher.init(Cipher.DECRYPT_MODE, key);
-        byte[] decryptedBytes = cipher.doFinal(Base64.getDecoder().decode(encryptedText));
+        byte[] decryptedBytes = cipher.doFinal(Base62Utils.decodeToBytes(encryptedText));
         return new String(decryptedBytes);
     }
 

--- a/Server/src/main/java/JGS/CasperEvent/global/util/Base62Utils.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/util/Base62Utils.java
@@ -22,4 +22,23 @@ public class Base62Utils {
         }
         return result;
     }
+
+    public static String encode(byte[] data) {
+        StringBuilder sb = new StringBuilder();
+        for (byte b : data) {
+            int value = b & 0xFF;
+            sb.append(encode(value));
+        }
+        return sb.toString();
+    }
+
+    public static byte[] decodeToBytes(String str) {
+        int length = str.length() / 2;
+        byte[] data = new byte[length];
+        for (int i = 0; i < length; i++) {
+            String part = str.substring(i * 2, i * 2 + 2);
+            data[i] = (byte) decode(part);
+        }
+        return data;
+    }
 }

--- a/Server/src/main/java/JGS/CasperEvent/global/util/Base62Utils.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/util/Base62Utils.java
@@ -15,30 +15,11 @@ public class Base62Utils {
         return sb.reverse().toString();
     }
 
-    public static long decode(String str){
+    public static long decode(String str) {
         long result = 0;
         for (int i = 0; i < str.length(); i++) {
             result = result * 62 + BASE62_CHARS.indexOf(str.charAt(i));
         }
         return result;
-    }
-
-    public static String encode(byte[] data) {
-        StringBuilder sb = new StringBuilder();
-        for (byte b : data) {
-            int value = b & 0xFF;
-            sb.append(encode(value));
-        }
-        return sb.toString();
-    }
-
-    public static byte[] decodeToBytes(String str) {
-        int length = str.length() / 2;
-        byte[] data = new byte[length];
-        for (int i = 0; i < length; i++) {
-            String part = str.substring(i * 2, i * 2 + 2);
-            data[i] = (byte) decode(part);
-        }
-        return data;
     }
 }

--- a/Server/src/main/resources/application-prod.yml
+++ b/Server/src/main/resources/application-prod.yml
@@ -26,7 +26,9 @@ spring:
       s3:
         bucket: ${S3_IMAGE_SERVER}
         region: ap-northeast-2
-
+  servlet:
+    multipart:
+      max-file-size: 10MB
 
 client:
   url: ${CLIENT_URL}

--- a/Server/src/main/resources/application-prod.yml
+++ b/Server/src/main/resources/application-prod.yml
@@ -21,6 +21,15 @@ spring:
       port: ${SPRING_REDIS_PORT}
   encryption:
     key: ${AES_128_ENCRYPTION_KEY}
+  cloud:
+    aws:
+      s3:
+        bucket: ${S3_IMAGE_SERVER}
+        region: ap-northeast-2
+      credentials:
+        accessKey: ${AWS_ACCESS_KEY}
+        secretKey: ${AWS_SECRET_KEY}
+
 
 client:
   url: ${CLIENT_URL}

--- a/Server/src/main/resources/application-prod.yml
+++ b/Server/src/main/resources/application-prod.yml
@@ -26,9 +26,6 @@ spring:
       s3:
         bucket: ${S3_IMAGE_SERVER}
         region: ap-northeast-2
-      credentials:
-        accessKey: ${AWS_ACCESS_KEY}
-        secretKey: ${AWS_SECRET_KEY}
 
 
 client:

--- a/Server/src/test/java/JGS/CasperEvent/domain/event/controller/eventController/LotteryEventControllerTest.java
+++ b/Server/src/test/java/JGS/CasperEvent/domain/event/controller/eventController/LotteryEventControllerTest.java
@@ -1,6 +1,11 @@
 package JGS.CasperEvent.domain.event.controller.eventController;
 
+import JGS.CasperEvent.domain.event.dto.RequestDto.lotteryEventDto.CasperBotRequestDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.CasperBotResponseDto;
 import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventResponseDto;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryParticipantResponseDto;
+import JGS.CasperEvent.domain.event.entity.casperBot.CasperBot;
+import JGS.CasperEvent.domain.event.entity.participants.LotteryParticipants;
 import JGS.CasperEvent.domain.event.service.adminService.AdminService;
 import JGS.CasperEvent.domain.event.service.eventService.LotteryEventService;
 import JGS.CasperEvent.domain.event.service.redisService.RedisService;
@@ -8,9 +13,9 @@ import JGS.CasperEvent.global.entity.BaseUser;
 import JGS.CasperEvent.global.enums.Role;
 import JGS.CasperEvent.global.jwt.service.UserService;
 import JGS.CasperEvent.global.jwt.util.JwtProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -22,8 +27,9 @@ import org.springframework.test.web.servlet.ResultActions;
 
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -36,6 +42,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class LotteryEventControllerTest {
     @Autowired
     private MockMvc mockMvc;
+    @Autowired
+    ObjectMapper objectMapper;
 
     @MockBean
     private LotteryEventService lotteryEventService;
@@ -46,27 +54,144 @@ public class LotteryEventControllerTest {
     @MockBean
     private RedisService redisService;
 
-    public String phoneNumber;
-    public String accessToken;
+    private BaseUser user;
+    private String phoneNumber;
+    private String accessToken;
+    private CasperBot casperBot;
+    private CasperBotRequestDto casperBotRequest;
+    private CasperBotResponseDto casperBotResponse;
+    private LotteryParticipants lotteryParticipants;
+    private LotteryEventResponseDto lotteryEventResponseDto;
 
     @BeforeEach
     void setUp() throws Exception {
         this.phoneNumber = "010-0000-0000";
 
+        // 베이스 유저 생성
+        user = new BaseUser(this.phoneNumber, Role.USER);
+        // 추첨 이벤트 참여자
+        lotteryParticipants = new LotteryParticipants(user);
         // userService 모킹
-        given(userService.verifyUser(any())).willReturn(new BaseUser(this.phoneNumber, Role.USER));
+        given(userService.verifyUser(any())).willReturn(user);
 
         // 엑세스 토큰 설정
         this.accessToken = getToken(this.phoneNumber);
 
         // 추첨 이벤트 조회
-        LotteryEventResponseDto lotteryEventResponseDto = new LotteryEventResponseDto(
+        lotteryEventResponseDto = new LotteryEventResponseDto(
                 LocalDateTime.of(2024, 8, 15, 0, 0, 0),
                 LocalDateTime.of(2024, 8, 1, 0, 0, 0),
                 LocalDateTime.of(2024, 8, 31, 0, 0, 0),
                 ChronoUnit.DAYS.between(LocalDateTime.of(2024, 8, 1, 0, 0, 0), LocalDateTime.of(2024, 8, 31, 0, 0, 0))
         );
+
+        casperBotRequest = CasperBotRequestDto.builder()
+                .eyeShape(0)
+                .eyePosition(0)
+                .mouthShape(0)
+                .color(0)
+                .sticker(0)
+                .name("name")
+                .expectation("expectation")
+                .referralId("QEszP1K8IqcapUHAVwikXA==").build();
+
+        casperBot = new CasperBot(casperBotRequest, "010-0000-0000");
+
+        casperBotResponse = CasperBotResponseDto.of(casperBot);
+    }
+
+    @Test
+    @DisplayName("추첨 이벤트 조회 API 성공 테스트")
+    void getLotteryEventAndServerTime() throws Exception {
+        //given
         given(lotteryEventService.getLotteryEvent()).willReturn(lotteryEventResponseDto);
+
+        //when
+        ResultActions perform = mockMvc.perform(get("/event/lottery")
+                .contentType(MediaType.APPLICATION_JSON));
+
+        //then
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.serverDateTime").value("2024-08-15T00:00:00"))
+                .andExpect(jsonPath("$.eventStartDate").value("2024-08-01T00:00:00"))
+                .andExpect(jsonPath("$.eventEndDate").value("2024-08-31T00:00:00"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("캐스퍼 봇 생성 API 성공 테스트")
+    void postCasperBot() throws Exception {
+        //given
+        String requestBody = objectMapper.writeValueAsString(casperBotRequest);
+        given(lotteryEventService.postCasperBot(user, casperBotRequest))
+                .willReturn(CasperBotResponseDto.of(casperBot));
+
+        //when
+        ResultActions perform = mockMvc.perform(post("/event/lottery/casperBot")
+                .header("Authorization", accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        //then
+        perform.andExpect(status().isCreated())
+                .andExpect(jsonPath("$.eyeShape").value(0))
+                .andExpect(jsonPath("$.eyePosition").value(0))
+                .andExpect(jsonPath("$.mouthShape").value(0))
+                .andExpect(jsonPath("$.color").value(0))
+                .andExpect(jsonPath("$.sticker").value(0))
+                .andExpect(jsonPath("$.name").value("name"))
+                .andExpect(jsonPath("$.expectation").value("expectation"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("응모 여부 조회 성공 테스트")
+    void GetLotteryParticipantsSuccessTest() throws Exception {
+        //given
+        given(lotteryEventService.getLotteryParticipant(user))
+                .willReturn(LotteryParticipantResponseDto.of(lotteryParticipants, casperBotResponse));
+
+        //when
+        ResultActions perform = mockMvc.perform(get("/event/lottery/applied")
+                .header("Authorization", accessToken)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        //then
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.linkClickedCount").value(0))
+                .andExpect(jsonPath("$.expectations").value(0))
+                .andExpect(jsonPath("$.appliedCount").value(1))
+                .andExpect(jsonPath("$.casperBot.eyeShape").value(0))
+                .andExpect(jsonPath("$.casperBot.eyePosition").value(0))
+                .andExpect(jsonPath("$.casperBot.mouthShape").value(0))
+                .andExpect(jsonPath("$.casperBot.color").value(0))
+                .andExpect(jsonPath("$.casperBot.sticker").value(0))
+                .andExpect(jsonPath("$.casperBot.name").value("name"))
+                .andExpect(jsonPath("$.casperBot.expectation").value("expectation"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("최근 100개 캐스퍼 봇 조회 성공 테스트")
+    void getCasperBotsSuccessTest() throws Exception {
+        //given
+        List<CasperBotResponseDto> recentData = new ArrayList<>();
+        for (int i = 0; i < 100; i++) {
+            recentData.add(casperBotResponse);
+        }
+        given(redisService.getRecentData())
+                .willReturn(recentData);
+
+        //when
+        ResultActions perform = mockMvc.perform(get("/event/lottery/caspers")
+                .header("Authorization", accessToken)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        //then
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(100))
+                .andDo(print());
+
     }
 
     String getToken(String phoneNumber) throws Exception {
@@ -86,24 +211,5 @@ public class LotteryEventControllerTest {
         int end = jsonString.indexOf("\"", start);
 
         return "Bearer " + jsonString.substring(start, end);
-    }
-
-    @Test
-    @DisplayName("추첨 이벤트 조회 API 성공 테스트")
-    void getLotteryEventAndServerTime() throws Exception {
-        //given
-        String token = this.accessToken;
-
-        //when
-        ResultActions perform = mockMvc.perform(get("/event/lottery")
-                .contentType(MediaType.APPLICATION_JSON));
-
-        //then
-        perform.andExpect(status().isOk())
-                .andExpect(jsonPath("$.serverDateTime").value("2024-08-15T00:00:00"))
-                .andExpect(jsonPath("$.eventStartDate").value("2024-08-01T00:00:00"))
-                .andExpect(jsonPath("$.eventEndDate").value("2024-08-31T00:00:00"))
-                .andDo(print());
-
     }
 }

--- a/Server/src/test/java/JGS/CasperEvent/domain/event/controller/eventController/LotteryEventControllerTest.java
+++ b/Server/src/test/java/JGS/CasperEvent/domain/event/controller/eventController/LotteryEventControllerTest.java
@@ -1,28 +1,73 @@
 package JGS.CasperEvent.domain.event.controller.eventController;
 
+import JGS.CasperEvent.domain.event.dto.ResponseDto.lotteryEventResponseDto.LotteryEventResponseDto;
+import JGS.CasperEvent.domain.event.service.adminService.AdminService;
+import JGS.CasperEvent.domain.event.service.eventService.LotteryEventService;
+import JGS.CasperEvent.domain.event.service.redisService.RedisService;
+import JGS.CasperEvent.global.entity.BaseUser;
+import JGS.CasperEvent.global.enums.Role;
+import JGS.CasperEvent.global.jwt.service.UserService;
+import JGS.CasperEvent.global.jwt.util.JwtProvider;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-@SpringBootTest
-@AutoConfigureMockMvc
-@ActiveProfiles("local")
+@WebMvcTest(LotteryEventController.class)
+@Import(JwtProvider.class)
 public class LotteryEventControllerTest {
     @Autowired
     private MockMvc mockMvc;
+
+    @MockBean
+    private LotteryEventService lotteryEventService;
+    @MockBean
+    private UserService userService;
+    @MockBean
+    private AdminService adminService;
+    @MockBean
+    private RedisService redisService;
+
+    public String phoneNumber;
+    public String accessToken;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        this.phoneNumber = "010-0000-0000";
+
+        // userService 모킹
+        given(userService.verifyUser(any())).willReturn(new BaseUser(this.phoneNumber, Role.USER));
+
+        // 엑세스 토큰 설정
+        this.accessToken = getToken(this.phoneNumber);
+
+        // 추첨 이벤트 조회
+        LotteryEventResponseDto lotteryEventResponseDto = new LotteryEventResponseDto(
+                LocalDateTime.of(2024, 8, 15, 0, 0, 0),
+                LocalDateTime.of(2024, 8, 1, 0, 0, 0),
+                LocalDateTime.of(2024, 8, 31, 0, 0, 0),
+                ChronoUnit.DAYS.between(LocalDateTime.of(2024, 8, 1, 0, 0, 0), LocalDateTime.of(2024, 8, 31, 0, 0, 0))
+        );
+        given(lotteryEventService.getLotteryEvent()).willReturn(lotteryEventResponseDto);
+    }
 
     String getToken(String phoneNumber) throws Exception {
         String requestBody = String.format("""
@@ -43,221 +88,22 @@ public class LotteryEventControllerTest {
         return "Bearer " + jsonString.substring(start, end);
     }
 
+    @Test
+    @DisplayName("추첨 이벤트 조회 API 성공 테스트")
+    void getLotteryEventAndServerTime() throws Exception {
+        //given
+        String token = this.accessToken;
 
-    @Nested
-    @DisplayName("캐스퍼 봇 생성 테스트")
-    class CasperBotTest {
-        //TODO: Expecation이 없을때, 있을때 값 증가 테스트
-        //TODO: DB에 없는 사용자 테스트 작성
-        @Test
-        @DisplayName("캐스퍼 봇 생성 성공 테스트")
-        public void createCasperBotSuccessTest() throws Exception {
-            //given
-            String accessToken = getToken("010-0000-0000");
+        //when
+        ResultActions perform = mockMvc.perform(get("/event/lottery")
+                .contentType(MediaType.APPLICATION_JSON));
 
-            String casperBotRequest = """
-                    {
-                    "eyeShape": "2",
-                    "eyePosition": "1",
-                    "mouthShape": "4",
-                    "color": "2",
-                    "sticker": "4",
-                    "name": "myCasperBot",
-                    "expectation": "myExpectation"
-                    }
-                    """;
+        //then
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.serverDateTime").value("2024-08-15T00:00:00"))
+                .andExpect(jsonPath("$.eventStartDate").value("2024-08-01T00:00:00"))
+                .andExpect(jsonPath("$.eventEndDate").value("2024-08-31T00:00:00"))
+                .andDo(print());
 
-            //when
-            ResultActions perform = mockMvc.perform(post("/event/lottery/casperBot")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(casperBotRequest)
-                    .header("Authorization", accessToken));
-
-            //then
-            perform
-                    .andExpect(status().isCreated())
-                    .andExpect(jsonPath("$.eyeShape").value(2))
-                    .andExpect(jsonPath("$.eyePosition").value(1))
-                    .andExpect(jsonPath("$.mouthShape").value(4))
-                    .andExpect(jsonPath("$.color").value(2))
-                    .andExpect(jsonPath("$.sticker").value(4))
-                    .andExpect(jsonPath("$.name").value("myCasperBot"))
-                    .andExpect(jsonPath("$.expectation").value("myExpectation"))
-                    .andDo(print());
-        }
-
-        @Test
-        @DisplayName("캐스퍼 봇 생성 실패 테스트 - 필수 필드 없음")
-        void createCasperBotFailureTest_RequiredFieldNotExist() throws Exception {
-            String accessToken = getToken("010-0000-0000");
-            //given
-            String casperBotRequest = """
-                    {
-                    "eye_shape": "2",
-                    "eye_position": "1",
-                    "mouth_shape": "4",
-                    "color": "2",
-                    "sticker": "4",
-                    "expectation": "myExpectation"
-                    }
-                    """;
-
-
-            //when
-            ResultActions perform = mockMvc.perform(post("/event/lottery/casperBot")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(casperBotRequest)
-                    .header("Authorization", accessToken));
-
-            //then
-            perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.errorCode").value("INVALID_PARAMETER"))
-                    .andDo(print());
-
-        }
-
-        @Test
-        @DisplayName("캐스퍼 봇 생성 실패 테스트 - 잘못된 값")
-        void createCasperBotSuccessTest_WrongValue() throws Exception {
-            //given
-            String accessToken = getToken("010-0000-0000");
-            String casperBotRequest = """
-                    {
-                    "eyeShape": "15",
-                    "eyePosition": "1",
-                    "mouthShape": "4",
-                    "color": "2",
-                    "sticker": "4",
-                    "name": "myCasperBot",
-                    "expectation": "myExpectation"
-                    }""";
-
-            //when
-            ResultActions perform = mockMvc.perform(post("/event/lottery/casperBot")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(casperBotRequest)
-                    .header("Authorization", accessToken));
-
-            //then
-            perform.andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.errorCode").value("INVALID_PARAMETER"))
-                    .andDo(print());
-        }
-
-        @Test
-        @DisplayName("캐스퍼 봇 생성 실패 테스트 - 인증 토큰 없음")
-        void createCasperBotSuccessTest_CookieNotPresent() throws Exception {
-            //given
-            String casperBotRequest = """
-                    {
-                    "eyeShape": "1",
-                    "eyePosition": "1",
-                    "mouthShape": "4",
-                    "color": "2",
-                    "sticker": "4",
-                    "name": "myCasperBot",
-                    "expectation": "myExpectation"
-                    }
-                    """;
-
-            //when
-            ResultActions perform = mockMvc.perform(post("/event/lottery/casperBot")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(casperBotRequest));
-
-            //then
-            perform.andExpect(status().isUnauthorized())
-                    .andDo(print());
-
-        }
-    }
-
-    @Nested
-    @DisplayName("캐스퍼 봇 응모 조회")
-    class CasperBotAppliedTest {
-        @Test
-        @DisplayName("캐스퍼 봇 응모 여부 조회 성공 - 유저가 존재할 경우")
-        void userHasAppliedCasperBotSuccessTest_PresentUser() throws Exception {
-            String accessToken = getToken("010-0000-0000");
-
-            String casperBotRequest = """
-                    {
-                    "eyeShape": "2",
-                    "eyePosition": "1",
-                    "mouthShape": "4",
-                    "color": "2",
-                    "sticker": "4",
-                    "name": "myCasperBot",
-                    "expectation": "myExpectation"
-                    }
-                    """;
-            //when
-            mockMvc.perform(post("/event/lottery/casperBot")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .content(casperBotRequest)
-                    .header("Authorization", accessToken));
-
-            //when
-            ResultActions perform = mockMvc.perform(get("/event/lottery/applied")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header("Authorization", accessToken));
-
-            //then
-            perform.andExpect(status().isOk())
-                    .andDo(print());
-
-        }
-
-        @Test
-        @DisplayName("캐스퍼 봇 응모 여부 조회 성공 - 유저가 존재하지 않는 경우")
-        void userHasAppliedCasperBotSuccessTest_NotPresentUser() throws Exception {
-            //given
-            String accessToken = getToken("010-1234-1234");
-
-            //when
-            ResultActions perform = mockMvc.perform(get("/event/lottery/applied")
-                    .contentType(MediaType.APPLICATION_JSON)
-                    .header("Authorization", accessToken));
-            //then
-            perform.andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.errorCode").value("USER_NOT_FOUND"))
-                    .andExpect(jsonPath("$.message").value("응모하지 않은 사용자입니다."))
-                    .andDo(print());
-
-        }
-
-        @Test
-        @DisplayName("캐스퍼 봇 응모 여부 조회 실패 - 토큰이 없는 경우")
-        void userHasAppliedCasperBotFailureTest_NotPresentCookie() throws Exception {
-            //when
-            ResultActions perform = mockMvc.perform(get("/event/lottery/applied")
-                    .contentType(MediaType.APPLICATION_JSON));
-            //then
-            perform.andExpect(status().isUnauthorized())
-                    .andExpect(jsonPath("$.errorCode").value("JWT_MISSING"))
-                    .andExpect(jsonPath("$.message").value("인증 토큰이 존재하지 않습니다."))
-                    .andDo(print());
-
-        }
-    }
-
-    @Nested
-    @DisplayName("캐스퍼 봇 조회 테스트")
-    class CasperBotResponseDtoTest {
-        @Test
-        @DisplayName("캐스퍼 봇 조회 테스트 성공 - Redis")
-        void GetCasperBotSuccessTest_redis() throws Exception {
-            for (int i = 0; i < 100; i++) {
-                ResultActions perform = mockMvc.perform(get("/event/lottery/caspers"));
-
-                //then
-                perform.andExpect(status().isOk())
-                        .andExpect(result -> {
-                            String responseBody = result.getResponse().getContentAsString();
-                            assertFalse(responseBody.isEmpty(), "Response body should not be empty");
-                        });
-
-            }
-        }
     }
 }

--- a/Server/src/test/java/JGS/CasperEvent/domain/event/controller/eventController/LotteryEventControllerTest.java
+++ b/Server/src/test/java/JGS/CasperEvent/domain/event/controller/eventController/LotteryEventControllerTest.java
@@ -1,6 +1,5 @@
 package JGS.CasperEvent.domain.event.controller.eventController;
 
-import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/Server/src/test/java/JGS/CasperEvent/domain/event/controller/eventController/RushEventControllerTest.java
+++ b/Server/src/test/java/JGS/CasperEvent/domain/event/controller/eventController/RushEventControllerTest.java
@@ -114,7 +114,7 @@ public class RushEventControllerTest {
                 rushEventRateResponseDto,
                 1,
                 1000,
-                315
+                true
         );
 
         given(rushEventService.getRushEventResult(any())).willReturn(rushEventResultResponseDto);
@@ -248,7 +248,7 @@ public class RushEventControllerTest {
                 .andExpect(jsonPath("$.rightOption").value(1000))
                 .andExpect(jsonPath("$.rank").value(1))
                 .andExpect(jsonPath("$.totalParticipants").value(1000))
-                .andExpect(jsonPath("$.winnerCount").value(315))
+                .andExpect(jsonPath("$.winner").value(true))
                 .andDo(print());
     }
 

--- a/Server/src/test/java/JGS/CasperEvent/domain/event/controller/eventController/RushEventControllerTest.java
+++ b/Server/src/test/java/JGS/CasperEvent/domain/event/controller/eventController/RushEventControllerTest.java
@@ -1,50 +1,127 @@
 package JGS.CasperEvent.domain.event.controller.eventController;
 
-import JGS.CasperEvent.domain.event.entity.event.RushEvent;
-import JGS.CasperEvent.domain.event.repository.eventRepository.RushEventRepository;
+import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.*;
+import JGS.CasperEvent.domain.event.service.adminService.AdminService;
+import JGS.CasperEvent.domain.event.service.eventService.RushEventService;
+import JGS.CasperEvent.global.entity.BaseUser;
+import JGS.CasperEvent.global.enums.CustomErrorCode;
+import JGS.CasperEvent.global.enums.Role;
+import JGS.CasperEvent.global.error.exception.CustomException;
+import JGS.CasperEvent.global.jwt.service.UserService;
+import JGS.CasperEvent.global.jwt.util.JwtProvider;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.context.annotation.Profile;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 
+import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest
-@AutoConfigureMockMvc
-@ActiveProfiles("local")
-class RushEventControllerTest {
+@WebMvcTest(RushEventController.class)
+@Import(JwtProvider.class)
+public class RushEventControllerTest {
 
     @Autowired
     private MockMvc mockMvc;
 
-    @Autowired
-    private RushEventRepository rushEventRepository;
+    @MockBean
+    private RushEventService rushEventService;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private AdminService adminService;
+
+    private String phoneNumber;
+    private String accessToken;
 
     @BeforeEach
-    void setUp() {
-        // 테스트 데이터 초기화
-        rushEventRepository.deleteAll(); // 기존 데이터 삭제
+    void setUp() throws Exception {
+        this.phoneNumber = "010-0000-0000";
 
-        // 새로운 생성자를 사용한 RushEvent 생성
-        RushEvent rushEvent1 = new RushEvent("https://example.com/image1.png", "First prize");
-        RushEvent rushEvent2 = new RushEvent("https://example.com/image2.png", "Second prize");
+        // userService 모킹
+        given(userService.verifyUser(any())).willReturn(new BaseUser(this.phoneNumber, Role.USER));
 
-        // 엔티티 저장
-        rushEventRepository.saveAll(Arrays.asList(rushEvent1, rushEvent2));
+        // 액세스 토큰 설정
+        this.accessToken = getToken(this.phoneNumber);
+
+        // Mock 데이터 설정
+        RushEventListResponseDto rushEventListResponseDto = new RushEventListResponseDto(
+                Arrays.asList(
+                        new MainRushEventResponseDto(37L, LocalDateTime.of(2024, 8, 11, 22, 0), LocalDateTime.of(2024, 8, 11, 22, 10)),
+                        new MainRushEventResponseDto(38L, LocalDateTime.of(2024, 8, 12, 22, 0), LocalDateTime.of(2024, 8, 12, 22, 10)),
+                        new MainRushEventResponseDto(39L, LocalDateTime.of(2024, 8, 13, 22, 0), LocalDateTime.of(2024, 8, 13, 22, 10)),
+                        new MainRushEventResponseDto(40L, LocalDateTime.of(2024, 8, 14, 22, 0), LocalDateTime.of(2024, 8, 14, 22, 10)),
+                        new MainRushEventResponseDto(41L, LocalDateTime.of(2024, 8, 15, 22, 0), LocalDateTime.of(2024, 8, 15, 22, 10)),
+                        new MainRushEventResponseDto(42L, LocalDateTime.of(2024, 8, 16, 22, 0), LocalDateTime.of(2024, 8, 16, 22, 10))
+                ),
+                LocalDateTime.of(2024, 8, 12, 13, 46, 29, 48782),
+                37L,
+                LocalDate.of(2024, 8, 11),
+                LocalDate.of(2024, 8, 16),
+                6L
+        );
+
+        given(rushEventService.getAllRushEvents()).willReturn(rushEventListResponseDto);
+
+        MainRushEventOptionsResponseDto mainRushEventOptionsResponseDto = new MainRushEventOptionsResponseDto(
+                new MainRushEventOptionResponseDto("leftMainText", "leftSubText"),
+                new MainRushEventOptionResponseDto("rightMainText", "rightSubText")
+        );
+
+        given(rushEventService.getTodayRushEventOptions()).willReturn(mainRushEventOptionsResponseDto);
+
+        ResultRushEventOptionResponseDto resultRushEventOptionResponseDto = new ResultRushEventOptionResponseDto(
+                "mainText",
+                "resultMainText",
+                "resultSubText"
+        );
+
+        given(rushEventService.getRushEventOptionResult(1)).willReturn(resultRushEventOptionResponseDto);
+        given(rushEventService.getRushEventOptionResult(2)).willReturn(resultRushEventOptionResponseDto);
+
+        // 예: apply 메서드가 정상적으로 동작하는 경우 (optionId가 2일 때)
+        willDoNothing().given(rushEventService).apply(any(BaseUser.class), eq(2));
+
+        // 예: apply 메서드가 실패하는 경우 (optionId가 1일 때)
+        willThrow(new CustomException("이미 응모한 회원입니다.", CustomErrorCode.CONFLICT))
+                .given(rushEventService).apply(any(BaseUser.class), eq(1));
+
+        RushEventRateResponseDto rushEventRateResponseDto = new RushEventRateResponseDto(
+                1,
+                315,
+                1000
+        );
+
+        given(rushEventService.getRushEventRate(any())).willReturn(rushEventRateResponseDto);
+
+        RushEventResultResponseDto rushEventResultResponseDto = new RushEventResultResponseDto(
+                rushEventRateResponseDto,
+                1,
+                1000,
+                315
+        );
+
+        given(rushEventService.getRushEventResult(any())).willReturn(rushEventResultResponseDto);
     }
 
     @Test
+    @DisplayName("메인화면 선착순 이벤트 전체 조회 API 테스트")
     public void getRushEventListAndServerTime() throws Exception {
         // when
         ResultActions perform = mockMvc.perform(get("/event/rush")
@@ -53,12 +130,144 @@ class RushEventControllerTest {
         // then
         perform.andExpect(status().isOk())
                 .andExpect(jsonPath("$.events").isArray())
-                .andExpect(jsonPath("$.events.length()").value(2))
-                .andExpect(jsonPath("$.events[0].prizeImageUrl").value("https://example.com/image1.png"))
-                .andExpect(jsonPath("$.events[0].prizeDescription").value("First prize"))
-                .andExpect(jsonPath("$.events[1].prizeImageUrl").value("https://example.com/image2.png"))
-                .andExpect(jsonPath("$.events[1].prizeDescription").value("Second prize"))
-                .andExpect(jsonPath("$.serverTime").exists())
+                .andExpect(jsonPath("$.events.length()").value(6))
+                .andExpect(jsonPath("$.events[0].rushEventId").value(37))
+                .andExpect(jsonPath("$.serverTime").value("2024-08-12T13:46:29.000048782"))
+                .andExpect(jsonPath("$.todayEventId").value(37))
+                .andExpect(jsonPath("$.eventStartDate").value("2024-08-11"))
+                .andExpect(jsonPath("$.eventEndDate").value("2024-08-16"))
+                .andExpect(jsonPath("$.activePeriod").value(6))
                 .andDo(print());
+    }
+
+    @Test
+    @DisplayName("오늘의 선착순 이벤트 조회 API 성공 테스트")
+    public void getTodayEventTest() throws Exception {
+        // given
+        String accessToken = this.accessToken;
+
+        // when
+        ResultActions perform = mockMvc.perform(get("/event/rush/today")
+                .header("Authorization", accessToken)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.leftOption.mainText").value("leftMainText"))
+                .andExpect(jsonPath("$.leftOption.subText").value("leftSubText"))
+                .andExpect(jsonPath("$.rightOption.mainText").value("rightMainText"))
+                .andExpect(jsonPath("$.rightOption.subText").value("rightSubText"))
+                .andDo(print());
+    }
+
+
+    @Test
+    @DisplayName("응모 성공 테스트 - Option ID 2")
+    public void applyRushEvent_Success() throws Exception {
+        String accessToken = this.accessToken;
+        int optionId = 2;
+
+        ResultActions perform = mockMvc.perform(post("/event/rush/options/{optionId}/apply", optionId)
+                .header("Authorization", accessToken)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        perform.andExpect(status().isNoContent())  // 204 No Content 응답 확인
+            .andDo(print());
+}
+
+    @Test
+    @DisplayName("응모 실패 테스트 - Option ID 1")
+    public void applyRushEvent_Failure_AlreadyApplied() throws Exception {
+        String accessToken = this.accessToken;
+        int optionId = 1;
+
+        ResultActions perform = mockMvc.perform(post("/event/rush/options/{optionId}/apply", optionId)
+                .header("Authorization", accessToken)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        perform.andExpect(status().isConflict())  // 409 Conflict 응답 확인
+                .andExpect(jsonPath("$.errorCode").value("CONFLICT"))
+                .andExpect(jsonPath("$.message").value("이미 응모한 회원입니다."))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("선택지 결과 조회 성공 테스트")
+    public void getResultOptionTest() throws Exception {
+        // given
+        String accessToken = this.accessToken;
+
+        int optionId = 1;
+
+        // when
+        ResultActions perform = mockMvc.perform(get("/event/rush/options/{optionId}/result", optionId)
+                .header("Authorization", accessToken)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.mainText").value("mainText"))
+                .andExpect(jsonPath("$.resultMainText").value("resultMainText"))
+                .andExpect(jsonPath("$.resultSubText").value("resultSubText"))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("밸런스 게임 비율 조회 API 테스트")
+    public void getRushEventRateTest() throws Exception {
+        // given
+        String accessToken = this.accessToken;
+
+        // when
+        ResultActions perform = mockMvc.perform(get("/event/rush/balance")
+                .header("Authorization", accessToken)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.optionId").value(1))
+                .andExpect(jsonPath("$.leftOption").value(315))
+                .andExpect(jsonPath("$.rightOption").value(1000))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("밸런스 게임 최종 결과 조회 API 테스트")
+    public void getRushEventResultTest() throws Exception {
+        // given
+        String accessToken = this.accessToken;
+
+        // when
+        ResultActions perform = mockMvc.perform(get("/event/rush/result")
+                .header("Authorization", accessToken)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.leftOption").value(315))
+                .andExpect(jsonPath("$.rightOption").value(1000))
+                .andExpect(jsonPath("$.rank").value(1))
+                .andExpect(jsonPath("$.totalParticipants").value(1000))
+                .andExpect(jsonPath("$.winnerCount").value(315))
+                .andDo(print());
+    }
+
+    private String getToken(String phoneNumber) throws Exception {
+        String requestBody = String.format("""
+                {
+                    "phoneNumber": "%s"
+                }
+                """, phoneNumber);
+
+        ResultActions perform = mockMvc.perform(post("/event/auth")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        String jsonString = perform.andReturn().getResponse().getContentAsString();
+        String tokenPrefix = "\"accessToken\":\"";
+        int start = jsonString.indexOf(tokenPrefix) + tokenPrefix.length();
+        int end = jsonString.indexOf("\"", start);
+
+        return "Bearer " + jsonString.substring(start, end);
     }
 }

--- a/Server/src/test/java/JGS/CasperEvent/domain/event/service/eventService/RushEventServiceTest.java
+++ b/Server/src/test/java/JGS/CasperEvent/domain/event/service/eventService/RushEventServiceTest.java
@@ -1,0 +1,44 @@
+package JGS.CasperEvent.domain.event.service.eventService;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class RushEventServiceTest {
+
+    @Test
+    void getAllRushEvents() {
+    }
+
+    @Test
+    void isExists() {
+    }
+
+    @Test
+    void apply() {
+    }
+
+    @Test
+    void getRushEventRate() {
+    }
+
+    @Test
+    void getRushEventResult() {
+    }
+
+    @Test
+    void getTodayRushEvent() {
+    }
+
+    @Test
+    void setTodayEventToRedis() {
+    }
+
+    @Test
+    void getTodayRushEventOptions() {
+    }
+
+    @Test
+    void getRushEventOptionResult() {
+    }
+}

--- a/Server/src/test/java/JGS/CasperEvent/domain/event/service/eventService/RushEventServiceTest.java
+++ b/Server/src/test/java/JGS/CasperEvent/domain/event/service/eventService/RushEventServiceTest.java
@@ -1,44 +1,584 @@
 package JGS.CasperEvent.domain.event.service.eventService;
 
+import JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto.*;
+import JGS.CasperEvent.domain.event.entity.event.RushEvent;
+import JGS.CasperEvent.domain.event.entity.event.RushOption;
+import JGS.CasperEvent.domain.event.entity.participants.RushParticipants;
+import JGS.CasperEvent.domain.event.repository.eventRepository.RushEventRepository;
+import JGS.CasperEvent.domain.event.repository.eventRepository.RushOptionRepository;
+import JGS.CasperEvent.domain.event.repository.participantsRepository.RushParticipantsRepository;
+import JGS.CasperEvent.global.entity.BaseUser;
+import JGS.CasperEvent.global.enums.CustomErrorCode;
+import JGS.CasperEvent.global.enums.Position;
+import JGS.CasperEvent.global.error.exception.CustomException;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 
-@SpringBootTest
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.mockito.BDDMockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+
+@ExtendWith(MockitoExtension.class)
 class RushEventServiceTest {
 
+    @Mock
+    private RushEventRepository rushEventRepository;
+    @Mock
+    private RushParticipantsRepository rushParticipantsRepository;
+    @Mock
+    private RedisTemplate<String, RushEventResponseDto> rushEventRedisTemplate;
+    @Mock
+    private RushOptionRepository rushOptionRepository;
+
+    @Mock
+    private ValueOperations<String, RushEventResponseDto> valueOperations;
+
+    @InjectMocks
+    RushEventService rushEventService;
+
     @Test
+    @DisplayName("모든 RushEvent 조회")
     void getAllRushEvents() {
+        // given
+        RushEventResponseDto todayEvent = new RushEventResponseDto(
+                1L,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1),
+                315,
+                "image-url",
+                "prize-description",
+                new HashSet<>()
+        );
+
+        List<RushEvent> rushEventList = List.of(
+                new RushEvent(),
+                new RushEvent()
+        );
+
+        List<MainRushEventResponseDto> mainRushEventResponseDtoList = rushEventList.stream()
+                .map(MainRushEventResponseDto::of).toList();
+
+        given(rushEventRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get("todayEvent")).willReturn(todayEvent);
+        given(rushEventRepository.findAll()).willReturn(rushEventList);
+
+        // when
+        RushEventListResponseDto allRushEvents = rushEventService.getAllRushEvents();
+
+        // then
+        assertNotNull(allRushEvents);
+        assertEquals(2, allRushEvents.getEvents().size());
+        assertEquals(allRushEvents.getTodayEventId(), 1);
     }
 
     @Test
+    @DisplayName("해당 유저가 선착순 이벤트 응모했는지 여부 테스트")
     void isExists() {
+        // given
+        BaseUser user = new BaseUser();
+        RushEventResponseDto todayEvent = new RushEventResponseDto(
+                1L,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1),
+                315,
+                "image-url",
+                "prize-description",
+                new HashSet<>()
+        );
+
+        given(rushEventRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(rushEventRedisTemplate.opsForValue().get("todayEvent")).willReturn(todayEvent);
+        given(rushParticipantsRepository.existsByRushEvent_RushEventIdAndBaseUser_Id(1L, user.getId())).willReturn(true);
+
+        // when
+        boolean exists = rushEventService.isExists(user.getId());
+
+        // then
+        assertTrue(exists);
     }
 
     @Test
+    @DisplayName("선착순 이벤트 응모 테스트")
     void apply() {
+        // given
+        BaseUser user = new BaseUser();
+        RushEventResponseDto todayEvent = new RushEventResponseDto(
+                1L,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1),
+                315,
+                "image-url",
+                "prize-description",
+                new HashSet<>()
+        );
+
+        given(rushEventRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(rushEventRedisTemplate.opsForValue().get("todayEvent")).willReturn(todayEvent);
+        given(rushParticipantsRepository.existsByRushEvent_RushEventIdAndBaseUser_Id(1L, user.getId())).willReturn(false);
+        RushEvent rushEvent = new RushEvent();
+        given(rushEventRepository.findById(1L)).willReturn(Optional.of(rushEvent));
+
+        // when
+        rushEventService.apply(user, 1);
+
+        // then
+        verify(rushParticipantsRepository).save(any(RushParticipants.class));
     }
 
     @Test
+    @DisplayName("선착순 이벤트 응모 테스트 (이미 응모한 유저인 경우)")
+    void apply2() {
+        // given
+        BaseUser user = new BaseUser();
+        RushEventResponseDto todayEvent = new RushEventResponseDto(
+                1L,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1),
+                315,
+                "image-url",
+                "prize-description",
+                new HashSet<>()
+        );
+
+        given(rushEventRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(rushEventRedisTemplate.opsForValue().get("todayEvent")).willReturn(todayEvent);
+        given(rushParticipantsRepository.existsByRushEvent_RushEventIdAndBaseUser_Id(1L, user.getId())).willReturn(true);
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () ->
+                rushEventService.apply(user, 1)
+        );
+
+        assertEquals(CustomErrorCode.CONFLICT, exception.getErrorCode());
+        assertEquals("이미 응모한 회원입니다.", exception.getMessage());
+    }
+
+
+    @Test
+    @DisplayName("선착순 이벤트 비율 조회 테스트")
     void getRushEventRate() {
+        // given
+        BaseUser user = new BaseUser();
+        RushEventResponseDto todayEvent = new RushEventResponseDto(
+                1L,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1),
+                315,
+                "image-url",
+                "prize-description",
+                new HashSet<>()
+        );
+
+        given(rushEventRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(rushEventRedisTemplate.opsForValue().get("todayEvent")).willReturn(todayEvent);
+        given(rushParticipantsRepository.getOptionIdByUserId(user.getId())).willReturn(Optional.of(1));
+        given(rushParticipantsRepository.countByRushEvent_RushEventIdAndOptionId(1L, 1)).willReturn(100L);
+        given(rushParticipantsRepository.countByRushEvent_RushEventIdAndOptionId(1L, 2)).willReturn(200L);
+
+        // when
+        RushEventRateResponseDto result = rushEventService.getRushEventRate(user);
+
+        // then
+        assertNotNull(result);
+        assertEquals(1, result.optionId());
+        assertEquals(100, result.leftOption());
+        assertEquals(200, result.rightOption());
     }
 
     @Test
+    @DisplayName("선착순 이벤트 결과 조회 테스트 (동점이 아니고 당첨인 경우)")
     void getRushEventResult() {
+        // given
+        BaseUser user = new BaseUser();
+        RushEventResponseDto todayEvent = new RushEventResponseDto(
+                1L,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1),
+                315,
+                "image-url",
+                "prize-description",
+                new HashSet<>()
+        );
+
+        given(rushEventRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(rushEventRedisTemplate.opsForValue().get("todayEvent")).willReturn(todayEvent);
+        given(rushParticipantsRepository.getOptionIdByUserId(user.getId())).willReturn(Optional.of(1));
+        given(rushParticipantsRepository.countByRushEvent_RushEventIdAndOptionId(1L, 1)).willReturn(700L);
+        given(rushParticipantsRepository.countByRushEvent_RushEventIdAndOptionId(1L, 2)).willReturn(500L);
+        given(rushParticipantsRepository.findUserRankByEventIdAndUserIdAndOptionId(1L, user.getId(), 1)).willReturn(300L);
+
+        // when
+        RushEventResultResponseDto result = rushEventService.getRushEventResult(user);
+ 
+        // then
+        assertNotNull(result);
+        assertEquals(700, result.getLeftOption());
+        assertEquals(500, result.getRightOption());
+        assertEquals(700, result.getTotalParticipants());
+        assertEquals(300, result.getRank());
+        assertTrue(result.isWinner());
     }
 
     @Test
+    @DisplayName("선착순 이벤트 결과 조회 테스트 (동점이 아니고 내가 선택한 옵션이 진 경우)")
+    void getRushEventResult2() {
+        // given
+        BaseUser user = new BaseUser();
+        RushEventResponseDto todayEvent = new RushEventResponseDto(
+                1L,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1),
+                315,
+                "image-url",
+                "prize-description",
+                new HashSet<>()
+        );
+
+        given(rushEventRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(rushEventRedisTemplate.opsForValue().get("todayEvent")).willReturn(todayEvent);
+        given(rushParticipantsRepository.getOptionIdByUserId(user.getId())).willReturn(Optional.of(2));
+        given(rushParticipantsRepository.countByRushEvent_RushEventIdAndOptionId(1L, 1)).willReturn(700L);
+        given(rushParticipantsRepository.countByRushEvent_RushEventIdAndOptionId(1L, 2)).willReturn(500L);
+        given(rushParticipantsRepository.findUserRankByEventIdAndUserIdAndOptionId(1L, user.getId(), 2)).willReturn(300L);
+
+        // when
+        RushEventResultResponseDto result = rushEventService.getRushEventResult(user);
+
+        // then
+        assertNotNull(result);
+        assertEquals(700, result.getLeftOption());
+        assertEquals(500, result.getRightOption());
+        assertEquals(500, result.getTotalParticipants());
+        assertEquals(300, result.getRank());
+        assertFalse(result.isWinner());
+    }
+
+    @Test
+    @DisplayName("선착순 이벤트 결과 조회 테스트 (동점이 아니고 내가 선택한 옵션이 이겼는데 등수에 미치지 못한 경우)")
+    void getRushEventResult3() {
+        // given
+        BaseUser user = new BaseUser();
+        RushEventResponseDto todayEvent = new RushEventResponseDto(
+                1L,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1),
+                315,
+                "image-url",
+                "prize-description",
+                new HashSet<>()
+        );
+
+        given(rushEventRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(rushEventRedisTemplate.opsForValue().get("todayEvent")).willReturn(todayEvent);
+        given(rushParticipantsRepository.getOptionIdByUserId(user.getId())).willReturn(Optional.of(1));
+        given(rushParticipantsRepository.countByRushEvent_RushEventIdAndOptionId(1L, 1)).willReturn(700L);
+        given(rushParticipantsRepository.countByRushEvent_RushEventIdAndOptionId(1L, 2)).willReturn(500L);
+        given(rushParticipantsRepository.findUserRankByEventIdAndUserIdAndOptionId(1L, user.getId(), 1)).willReturn(400L);
+
+        // when
+        RushEventResultResponseDto result = rushEventService.getRushEventResult(user);
+
+        // then
+        assertNotNull(result);
+        assertEquals(700, result.getLeftOption());
+        assertEquals(500, result.getRightOption());
+        assertEquals(700, result.getTotalParticipants());
+        assertEquals(400, result.getRank());
+        assertFalse(result.isWinner());
+    }
+
+    @Test
+    @DisplayName("선착순 이벤트 결과 조회 테스트 (동점인데 당첨된 경우)")
+    void getRushEventResult4() {
+        // given
+        BaseUser user = new BaseUser();
+        RushEventResponseDto todayEvent = new RushEventResponseDto(
+                1L,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1),
+                315,
+                "image-url",
+                "prize-description",
+                new HashSet<>()
+        );
+
+        given(rushEventRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(rushEventRedisTemplate.opsForValue().get("todayEvent")).willReturn(todayEvent);
+        given(rushParticipantsRepository.getOptionIdByUserId(user.getId())).willReturn(Optional.of(1));
+        given(rushParticipantsRepository.countByRushEvent_RushEventIdAndOptionId(1L, 1)).willReturn(500L);
+        given(rushParticipantsRepository.countByRushEvent_RushEventIdAndOptionId(1L, 2)).willReturn(500L);
+        given(rushParticipantsRepository.findUserRankByEventIdAndUserId(1L, user.getId())).willReturn(300L);
+        // when
+        RushEventResultResponseDto result = rushEventService.getRushEventResult(user);
+
+        // then
+        assertNotNull(result);
+        assertEquals(500, result.getLeftOption());
+        assertEquals(500, result.getRightOption());
+        assertEquals(1000, result.getTotalParticipants());
+        assertEquals(300, result.getRank());
+        assertTrue(result.isWinner());
+    }
+
+    @Test
+    @DisplayName("선착순 이벤트 결과 조회 테스트 (동점인데 등수에 미치지 못한 경우)")
+    void getRushEventResult5() {
+        // given
+        BaseUser user = new BaseUser();
+        RushEventResponseDto todayEvent = new RushEventResponseDto(
+                1L,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1),
+                315,
+                "image-url",
+                "prize-description",
+                new HashSet<>()
+        );
+
+        given(rushEventRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(rushEventRedisTemplate.opsForValue().get("todayEvent")).willReturn(todayEvent);
+        given(rushParticipantsRepository.getOptionIdByUserId(user.getId())).willReturn(Optional.of(1));
+        given(rushParticipantsRepository.countByRushEvent_RushEventIdAndOptionId(1L, 1)).willReturn(500L);
+        given(rushParticipantsRepository.countByRushEvent_RushEventIdAndOptionId(1L, 2)).willReturn(500L);
+        given(rushParticipantsRepository.findUserRankByEventIdAndUserId(1L, user.getId())).willReturn(400L);
+        // when
+        RushEventResultResponseDto result = rushEventService.getRushEventResult(user);
+
+        // then
+        assertNotNull(result);
+        assertEquals(500, result.getLeftOption());
+        assertEquals(500, result.getRightOption());
+        assertEquals(1000, result.getTotalParticipants());
+        assertEquals(400, result.getRank());
+        assertFalse(result.isWinner());
+    }
+
+    @Test
+    @DisplayName("오늘의 선착순 이벤트 DB에서 가져오기 테스트")
     void getTodayRushEvent() {
+        // given
+        LocalDate today = LocalDate.now();
+        RushEvent rushEvent = new RushEvent();
+        given(rushEventRepository.findByEventDate(today)).willReturn(List.of(rushEvent));
+
+        // when
+        RushEventResponseDto result = rushEventService.getTodayRushEvent(today);
+
+        // then
+        assertNotNull(result);
+        assertEquals(rushEvent.getRushEventId(), result.rushEventId());
+    }
+
+    @Test
+    @DisplayName("오늘의 선착순 이벤트 DB에서 가져오기 테스트 (Redis에 선착순 이벤트가 없는 경우)")
+    void getTodayRushEvent2() {
+        // given
+        LocalDate today = LocalDate.now();
+        given(rushEventRepository.findByEventDate(today)).willReturn(List.of());
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () ->
+                rushEventService.getTodayRushEvent(today)
+        );
+
+        assertEquals(CustomErrorCode.NO_RUSH_EVENT, exception.getErrorCode());
+        assertEquals("선착순 이벤트가 존재하지않습니다.", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("오늘의 선착순 이벤트 DB에서 가져오기 테스트 (Redis에 선착순 이벤트가 2개 이상인 경우)")
+    void getTodayRushEvent3() {
+        // given
+        LocalDate today = LocalDate.now();
+        RushEvent rushEvent1 = new RushEvent();
+        RushEvent rushEvent2 = new RushEvent();
+        given(rushEventRepository.findByEventDate(today)).willReturn(List.of(
+                rushEvent1, rushEvent2
+        ));
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () ->
+                rushEventService.getTodayRushEvent(today)
+        );
+
+        assertEquals(CustomErrorCode.MULTIPLE_RUSH_EVENTS_FOUND, exception.getErrorCode());
+        assertEquals("선착순 이벤트가 2개 이상 존재합니다.", exception.getMessage());
     }
 
     @Test
     void setTodayEventToRedis() {
+        // given
+        RushEvent rushEvent = new RushEvent();
+        RushOption rushOption = new RushOption();
+        given(rushEventRepository.save(any(RushEvent.class))).willReturn(rushEvent);
+        given(rushOptionRepository.save(any(RushOption.class))).willReturn(rushOption);
+        given(rushEventRedisTemplate.opsForValue()).willReturn(valueOperations);
+
+        // when
+        rushEventService.setTodayEventToRedis();
+
+        // then
+        verify(rushParticipantsRepository).deleteAllInBatch();
+        verify(rushOptionRepository).deleteAllInBatch();
+        verify(rushEventRepository).deleteAllInBatch();
+        verify(rushEventRedisTemplate.opsForValue()).set(eq("todayEvent"), any(RushEventResponseDto.class));
     }
 
     @Test
     void getTodayRushEventOptions() {
+        // given
+        RushEventResponseDto todayEvent = new RushEventResponseDto(
+                1L,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1),
+                315,
+                "image-url",
+                "prize-description",
+                Set.of(
+                        new RushEventOptionResponseDto(1L, "leftMainText", "leftSubText", "resultMainText", "resultSubText", "leftImageUrl", Position.LEFT, LocalDateTime.now(), LocalDateTime.now()),
+                        new RushEventOptionResponseDto(2L, "rightMainText", "rightSubText", "resultMainText", "resultSubText", "rightImageUrl", Position.RIGHT, LocalDateTime.now(), LocalDateTime.now())
+                )
+        );
+
+        given(rushEventRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(rushEventRedisTemplate.opsForValue().get("todayEvent")).willReturn(todayEvent);
+
+        // when
+        MainRushEventOptionsResponseDto result = rushEventService.getTodayRushEventOptions();
+
+        // then
+        assertNotNull(result);
+        assertEquals("leftMainText", result.leftOption().mainText());
+        assertEquals("rightMainText", result.rightOption().mainText());
     }
 
     @Test
+    @DisplayName("선택지 결과 조회 (옵션 개수가 2개인 경우)")
     void getRushEventOptionResult() {
+        // given
+        int optionId = 1;
+        RushEventResponseDto todayEvent = new RushEventResponseDto(
+                1L,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1),
+                315,
+                "image-url",
+                "prize-description",
+                Set.of(
+                        new RushEventOptionResponseDto(1L, "leftMainText", "leftSubText", "resultMainText", "resultSubText", "leftImageUrl", Position.LEFT, LocalDateTime.now(), LocalDateTime.now()),
+                        new RushEventOptionResponseDto(2L, "rightMainText", "rightSubText", "resultMainText", "resultSubText", "rightImageUrl", Position.RIGHT, LocalDateTime.now(), LocalDateTime.now())
+                )
+        );
+
+        given(rushEventRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(rushEventRedisTemplate.opsForValue().get("todayEvent")).willReturn(todayEvent);
+
+        // when
+        ResultRushEventOptionResponseDto result = rushEventService.getRushEventOptionResult(optionId);
+
+        // then
+        assertNotNull(result);
+        assertEquals("leftMainText", result.mainText());
+    }
+
+    @Test
+    @DisplayName("선택지 결과 조회 (옵션 개수가 3개 이상인 경우)")
+    void getRushEventOptionResult2() {
+        // given
+        int optionId = 1;
+        RushEventResponseDto todayEvent = new RushEventResponseDto(
+                1L,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1),
+                315,
+                "image-url",
+                "prize-description",
+                Set.of(
+                        new RushEventOptionResponseDto(1L, "leftMainText", "leftSubText", "resultMainText", "resultSubText", "leftImageUrl", Position.LEFT, LocalDateTime.now(), LocalDateTime.now()),
+                        new RushEventOptionResponseDto(2L, "rightMainText", "rightSubText", "resultMainText", "resultSubText", "rightImageUrl", Position.RIGHT, LocalDateTime.now(), LocalDateTime.now()),
+                        new RushEventOptionResponseDto(3L, "rightMainText", "rightSubText", "resultMainText", "resultSubText", "rightImageUrl", Position.RIGHT, LocalDateTime.now(), LocalDateTime.now())
+                )
+        );
+
+        given(rushEventRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(rushEventRedisTemplate.opsForValue().get("todayEvent")).willReturn(todayEvent);
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () ->
+            rushEventService.getRushEventOptionResult(optionId)
+        );
+
+        assertEquals(CustomErrorCode.INVALID_RUSH_EVENT_OPTIONS_COUNT, exception.getErrorCode());
+        assertEquals("해당 이벤트의 선택지가 2개가 아닙니다.", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("선택지 결과 조회 (사용자가 선택한 선택지가 1 또는 2가 아닌 경우)")
+    void getRushEventOptionResult3() {
+        // given
+        int optionId = 3;
+        RushEventResponseDto todayEvent = new RushEventResponseDto(
+                1L,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1),
+                315,
+                "image-url",
+                "prize-description",
+                Set.of(
+                        new RushEventOptionResponseDto(1L, "leftMainText", "leftSubText", "resultMainText", "resultSubText", "leftImageUrl", Position.LEFT, LocalDateTime.now(), LocalDateTime.now()),
+                        new RushEventOptionResponseDto(2L, "rightMainText", "rightSubText", "resultMainText", "resultSubText", "rightImageUrl", Position.RIGHT, LocalDateTime.now(), LocalDateTime.now())
+                )
+        );
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () ->
+                rushEventService.getRushEventOptionResult(optionId)
+        );
+
+        assertEquals(CustomErrorCode.INVALID_RUSH_EVENT_OPTION_ID, exception.getErrorCode());
+        assertEquals("optionId는 1 또는 2여야 합니다.", exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("선택지 결과 조회 (사용자가 선택한 옵션이 DB에 없는 경우)")
+    void getRushEventOptionResult4() {
+        // given
+        int optionId = 1;
+        RushEventResponseDto todayEvent = new RushEventResponseDto(
+                1L,
+                LocalDateTime.now(),
+                LocalDateTime.now().plusDays(1),
+                315,
+                "image-url",
+                "prize-description",
+                Set.of(
+                        new RushEventOptionResponseDto(2L, "rightMainText", "rightSubText", "resultMainText", "resultSubText", "rightImageUrl", Position.RIGHT, LocalDateTime.now(), LocalDateTime.now()),
+                        new RushEventOptionResponseDto(3L, "rightMainText", "rightSubText", "resultMainText", "resultSubText", "rightImageUrl", Position.RIGHT, LocalDateTime.now(), LocalDateTime.now())
+                )
+        );
+
+        given(rushEventRedisTemplate.opsForValue()).willReturn(valueOperations);
+        given(rushEventRedisTemplate.opsForValue().get("todayEvent")).willReturn(todayEvent);
+
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, () ->
+                rushEventService.getRushEventOptionResult(optionId)
+        );
+
+        assertEquals(CustomErrorCode.NO_RUSH_EVENT_OPTION, exception.getErrorCode());
+        assertEquals("사용자가 선택한 선택지가 존재하지 않습니다.", exception.getMessage());
     }
 }


### PR DESCRIPTION
## 🖥️ Preview

## ✏️ 한 일
- 단축 URL 생성
    - API 요청 시 사용자의 인증 토큰을 통해 유저 아이디를 식별하고, 이 유저 아이디를 `AES-128`을 이용해 `암호화` 후 단축 전 원본 URL을 생성한다.
        - 암호화한 이유는?
            - 우리 서비스에서 사용하는 유저 아이디는 유저의 전화번호
            - 최종적으로는 단축 url을 클릭한 유저는 단축 url을 생성한 유저의 식별자를 가지고 있어야 하는데, 전화번호가 그대로 노출된다면 곤란
        - Why AES-128?
            - AES-128는 128비트 키를 사용하는 암호화 방식
            - 암호화와 복호화가 빠르며, 메모리와 CPU 성능을 적게 소모한다.
            - AES-256, AES-192는 더 높은 안전성을 제공하지만, AES-128도 `충분한 안정성`을 제공하며, `더 높은 성능`을 보임
    - 생성된 URL을 테이블에 저장 후 해당 로우의 인덱스를 `BASE62`를 통해 인코딩한다.
        - Why Base62?
            - Base64 = 알파벳 대문자 26개, 알파벳 소문자 26개, 숫자 10개, 특수 문자 2개 (`+` , `/` )를 사용한 64진법 인코딩
            - Base62 = 알파벳 대문자 26개, 알파벳 소문자 26개, 숫자 10개 사용한 62진법 인코딩
            - `+` , `/` 이 포함된다면 Query String이 제대로 동작하지 않음
    - 인코딩 값을 통해 단축 URL을 만든다. (`https://hybridjgs.shop/link/b`)
        - 백엔드 서버를 단축 URL 서버로 사용한 이유는?
            - 구현 편의성: 별도의 서버를 사용할 필요 없으며, 기존에 사용하는 서버와 DB 사용 가능
            - 확장성을 고려한다면 별도의 URL 단축 서버를 만들거나, AWS Lambda 등 서버리스 환경도 고려해보았으나, 현재 개발 여건 상 추가적인 서버를 구축하기는 어렵다고 판단.
    - 단축 URL에 접속한 사용자는 API 서버에 의해 원본 도메인으로 리다이렉션됨
- 추첨 이벤트 생성
    - 추첨 이벤트는 데이터베이스에 하나만 존재하도록 설정
    - AtomicInteger 통해서 총 참여 횟수 관리
- 링크 클릭 가산점 부여 로직 작성
- 프론트엔드 피드백 수정
    - 추첨 이벤트 조회 시 날짜와 시간 분리해서 반환
    - 추천인 ID에 따라 가산점 부여 로직 추가
- 선착순 이벤트 API 구현
    
    
- 선착순 이벤트 생성 API 구현
    - S3 이용하여 이미지 서버 구현
    - 개발 환경과 배포 환경의 S3 설정을 분리하여 보안 향상
- 선착순 이벤트 전체 조회 API 구현
- 선착순 이벤트 참여자 API
    - Pagable 객체를 이용한 페이지네이션 구현
- 이미지 업로드 API 구현
    - S3에 이미지 업로드할 수 있는 API
- 선착순 이벤트 수정 API 구현
- 가중치 적용한 추첨 알고리즘 구현
    - 기존 알고리즘과 구상한 알고리즘을 간단히 구현하여 성능 테스트 했습니다.
    - 기존 알고리즘의 성능이 우수하여 기존 알고리즘을 통해 구현했습니다.
## ❗️ 발생한 이슈 (해결 방안)

## ❓ 논의가 필요한 사항