### PR TITLE
fix: 순환 참조 에러를 막기 위해 BaseUser의 participants 필드에 @JsonIgnore 애노테이션 추가

### DIFF
--- a/Server/src/main/java/JGS/CasperEvent/global/entity/BaseUser.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/entity/BaseUser.java
@@ -3,6 +3,7 @@ package JGS.CasperEvent.global.entity;
 import JGS.CasperEvent.domain.event.entity.participants.LotteryParticipants;
 import JGS.CasperEvent.domain.event.entity.participants.RushParticipants;
 import JGS.CasperEvent.global.enums.Role;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lombok.EqualsAndHashCode;
@@ -19,10 +20,12 @@ public class BaseUser extends BaseEntity {
 
     @JsonManagedReference
     @OneToOne(mappedBy = "baseUser", cascade = CascadeType.ALL)
+    @JsonIgnore
     private LotteryParticipants lotteryParticipants;
 
     @JsonManagedReference
     @OneToOne(mappedBy = "baseUser", cascade = CascadeType.ALL)
+    @JsonIgnore
     private RushParticipants rushParticipants;
 
     public void updateLotteryParticipants(LotteryParticipants lotteryParticipant) {


### PR DESCRIPTION
## 🖥️ Preview

## ✏️ 한 일
* BaseUser의 Participants 필드에 @JsonIgnore 필드를 붙여서 Json 변환 시 순환 참조 에러 해결

## ❗️ 발생한 이슈 (해결 방안)

## ❓ 논의가 필요한 사항