### PR TITLE
Feature/#180 fix rush event result

### DIFF
--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventRateResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventRateResponseDto.java
@@ -1,4 +1,4 @@
 package JGS.CasperEvent.domain.event.dto.ResponseDto.rushEventResponseDto;
 
-public record RushEventRateResponseDto(int optionId, long leftOption, long rightOption) {
+public record RushEventRateResponseDto(Integer optionId, Long leftOption, Long rightOption) {
 }

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventResultResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventResultResponseDto.java
@@ -6,17 +6,9 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class RushEventResultResponseDto {
-    private final long leftOption;
-    private final long rightOption;
-    private final long rank;
-    private final long totalParticipants;
-    private final boolean isWinner;
-
-    public RushEventResultResponseDto(RushEventRateResponseDto rushEventRateResponseDto, long rank, long totalParticipants, boolean isWinner) {
-        this.leftOption = rushEventRateResponseDto.leftOption();
-        this.rightOption = rushEventRateResponseDto.rightOption();
-        this.rank = rank;
-        this.totalParticipants = totalParticipants;
-        this.isWinner = isWinner;
-    }
+    private final Long leftOption;
+    private final Long rightOption;
+    private final Long rank;
+    private final Long totalParticipants;
+    private final Boolean isWinner;
 }

--- a/Server/src/main/java/JGS/CasperEvent/global/interceptor/RequestInterceptor.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/interceptor/RequestInterceptor.java
@@ -38,6 +38,11 @@ public class RequestInterceptor implements HandlerInterceptor {
 
     @Override
     public void afterCompletion(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull Object handler, Exception ex) {
+        // 예외 발생 시 로그 추가
+        if (ex != null) {
+            log.error("Exception [{}]", ex.getMessage());
+        }
+
         log.info("Response {} [{}]", response.getStatus(), handler);
 
         // 요청이 완료된 후 MDC에서 requestId 제거

--- a/Server/src/main/java/JGS/CasperEvent/global/jwt/filter/VerifyUserFilter.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/jwt/filter/VerifyUserFilter.java
@@ -31,7 +31,7 @@ public class VerifyUserFilter implements Filter {
                 request.setAttribute(AUTHENTICATE_USER, user);
                 chain.doFilter(request, response);
             } catch (Exception e) {
-                log.error("Fail User Verify");
+                log.error("Fail User Verify: {}", e.getMessage());
                 HttpServletResponse httpServletResponse = (HttpServletResponse) response;
                 httpServletResponse.sendError(HttpStatus.BAD_REQUEST.value(), e.getMessage());
             }

--- a/Server/src/test/java/JGS/CasperEvent/domain/event/controller/eventController/RushEventControllerTest.java
+++ b/Server/src/test/java/JGS/CasperEvent/domain/event/controller/eventController/RushEventControllerTest.java
@@ -104,16 +104,17 @@ public class RushEventControllerTest {
 
         RushEventRateResponseDto rushEventRateResponseDto = new RushEventRateResponseDto(
                 1,
-                315,
-                1000
+                315L,
+                1000L
         );
 
         given(rushEventService.getRushEventRate(any())).willReturn(rushEventRateResponseDto);
 
         RushEventResultResponseDto rushEventResultResponseDto = new RushEventResultResponseDto(
-                rushEventRateResponseDto,
-                1,
-                1000,
+                315L,
+                1000L,
+                1L,
+                1000L,
                 true
         );
 

--- a/Server/src/test/java/JGS/CasperEvent/domain/event/service/eventService/RushEventServiceTest.java
+++ b/Server/src/test/java/JGS/CasperEvent/domain/event/service/eventService/RushEventServiceTest.java
@@ -228,7 +228,7 @@ class RushEventServiceTest {
         assertEquals(500, result.getRightOption());
         assertEquals(700, result.getTotalParticipants());
         assertEquals(300, result.getRank());
-        assertTrue(result.isWinner());
+        assertTrue(result.getIsWinner());
     }
 
     @Test
@@ -262,7 +262,7 @@ class RushEventServiceTest {
         assertEquals(500, result.getRightOption());
         assertEquals(500, result.getTotalParticipants());
         assertEquals(300, result.getRank());
-        assertFalse(result.isWinner());
+        assertFalse(result.getIsWinner());
     }
 
     @Test
@@ -296,7 +296,7 @@ class RushEventServiceTest {
         assertEquals(500, result.getRightOption());
         assertEquals(700, result.getTotalParticipants());
         assertEquals(400, result.getRank());
-        assertFalse(result.isWinner());
+        assertFalse(result.getIsWinner());
     }
 
     @Test
@@ -329,7 +329,7 @@ class RushEventServiceTest {
         assertEquals(500, result.getRightOption());
         assertEquals(1000, result.getTotalParticipants());
         assertEquals(300, result.getRank());
-        assertTrue(result.isWinner());
+        assertTrue(result.getIsWinner());
     }
 
     @Test
@@ -362,7 +362,7 @@ class RushEventServiceTest {
         assertEquals(500, result.getRightOption());
         assertEquals(1000, result.getTotalParticipants());
         assertEquals(400, result.getRank());
-        assertFalse(result.isWinner());
+        assertFalse(result.getIsWinner());
     }
 
     @Test


### PR DESCRIPTION
## 🖥️ Preview

close #180 

## ✏️ 한 일
* 선착순 이벤트 결과 조회 API 에서 해당 유저가 응모하지 않은 경우 leftOption, rightOption 을 제외한 모든 필드를 null로 반환하도록 추가
* 예외 발생 시 error 로그 남기도록 변경

## ❗️ 발생한 이슈 (해결 방안)

## ❓ 논의가 필요한 사항