### PR TITLE
Feature/#192 rush event result fix

### DIFF
--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/RequestDto/AdminRequestDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/RequestDto/AdminRequestDto.java
@@ -1,9 +1,7 @@
 package JGS.CasperEvent.domain.event.dto.RequestDto;
 
 import jakarta.validation.constraints.NotNull;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
+import lombok.*;
 
 @Getter
 @Builder

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventResultResponseDto.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/dto/ResponseDto/rushEventResponseDto/RushEventResultResponseDto.java
@@ -6,6 +6,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class RushEventResultResponseDto {
+    private final Integer optionId;
     private final Long leftOption;
     private final Long rightOption;
     private final Long rank;

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/RushEventService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/RushEventService.java
@@ -115,6 +115,7 @@ public class RushEventService {
         Optional<Integer> optionIdOptional = rushParticipantsRepository.getOptionIdByUserId(user.getId());
         if (optionIdOptional.isEmpty()) {
             return new RushEventResultResponseDto(
+                    null,
                     leftOption,
                     rightOption,
                     null,
@@ -122,6 +123,9 @@ public class RushEventService {
                     null
             );
         }
+
+        // optionId 를 꺼냄
+        int optionId = optionIdOptional.get();
 
         // 동점인 경우
         if (leftOption == rightOption) {
@@ -134,10 +138,8 @@ public class RushEventService {
             // 당첨 여부
             boolean isWinner = rank <= todayRushEvent.winnerCount();
 
-            return new RushEventResultResponseDto(leftOption, rightOption, rank, totalParticipants, isWinner);
+            return new RushEventResultResponseDto(optionId, leftOption, rightOption, rank, totalParticipants, isWinner);
         }
-
-        int optionId = optionIdOptional.get();
 
         long totalParticipants = (optionId == 1 ? leftOption : rightOption);
 
@@ -146,13 +148,13 @@ public class RushEventService {
 
         // 해당 유저가 선택한 옵션이 패배한 경우
         if ((optionId == 1 && leftOption < rightOption) || (optionId == 2 && leftOption > rightOption)) {
-            return new RushEventResultResponseDto(leftOption, rightOption, rank, totalParticipants, false);
+            return new RushEventResultResponseDto(optionId, leftOption, rightOption, rank, totalParticipants, false);
         }
 
         // 당첨 여부
         boolean isWinner = rank <= todayRushEvent.winnerCount();
 
-        return new RushEventResultResponseDto(leftOption, rightOption, rank, totalParticipants, isWinner);
+        return new RushEventResultResponseDto(optionId, leftOption, rightOption, rank, totalParticipants, isWinner);
     }
 
     // 오늘의 이벤트를 DB에 꺼내서 반환

--- a/Server/src/main/resources/logback-spring.xml
+++ b/Server/src/main/resources/logback-spring.xml
@@ -1,5 +1,4 @@
 <configuration>
-
     <!-- 공통 콘솔 출력 설정 -->
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
@@ -11,58 +10,21 @@
     <springProfile name="local">
         <appender name="INFO_FILE_LOCAL" class="ch.qos.logback.core.rolling.RollingFileAppender">
             <file>./logs/info.log</file>
-            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                <fileNamePattern>./logs/info.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>./logs/info.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+                <maxFileSize>10MB</maxFileSize>
                 <maxHistory>30</maxHistory>
+                <totalSizeCap>1GB</totalSizeCap>
             </rollingPolicy>
             <encoder>
                 <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg [%X{requestId}]%n</pattern>
             </encoder>
-            <filter class="ch.qos.logback.classic.filter.LevelFilter">
-                <level>INFO</level>
-                <onMatch>ACCEPT</onMatch>
-                <onMismatch>DENY</onMismatch>
-            </filter>
-        </appender>
-
-        <appender name="ERROR_FILE_LOCAL" class="ch.qos.logback.core.rolling.RollingFileAppender">
-            <file>./logs/error.log</file>
-            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                <fileNamePattern>./logs/error.%d{yyyy-MM-dd}.log</fileNamePattern>
-                <maxHistory>30</maxHistory>
-            </rollingPolicy>
-            <encoder>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg [%X{requestId}]%n</pattern>
-            </encoder>
-            <filter class="ch.qos.logback.classic.filter.LevelFilter">
-                <level>ERROR</level>
-                <onMatch>ACCEPT</onMatch>
-                <onMismatch>DENY</onMismatch>
-            </filter>
-        </appender>
-
-        <appender name="WARN_FILE_LOCAL" class="ch.qos.logback.core.rolling.RollingFileAppender">
-            <file>./logs/warn.log</file>
-            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                <fileNamePattern>./logs/warn.%d{yyyy-MM-dd}.log</fileNamePattern>
-                <maxHistory>30</maxHistory>
-            </rollingPolicy>
-            <encoder>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg [%X{requestId}]%n</pattern>
-            </encoder>
-            <filter class="ch.qos.logback.classic.filter.LevelFilter">
-                <level>WARN</level>
-                <onMatch>ACCEPT</onMatch>
-                <onMismatch>DENY</onMismatch>
-            </filter>
         </appender>
 
         <!-- 루트 로거 설정 -->
         <root level="INFO">
             <appender-ref ref="STDOUT" />
             <appender-ref ref="INFO_FILE_LOCAL" />
-            <appender-ref ref="ERROR_FILE_LOCAL" />
-            <appender-ref ref="WARN_FILE_LOCAL" />
         </root>
     </springProfile>
 
@@ -70,59 +32,21 @@
     <springProfile name="prod">
         <appender name="INFO_FILE_PROD" class="ch.qos.logback.core.rolling.RollingFileAppender">
             <file>/logs/info.log</file>
-            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                <fileNamePattern>/logs/info.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>/logs/info.%d{yyyy-MM-dd}.%i.log.gz</fileNamePattern>
+                <maxFileSize>10MB</maxFileSize>
                 <maxHistory>30</maxHistory>
+                <totalSizeCap>1GB</totalSizeCap>
             </rollingPolicy>
             <encoder>
                 <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg [%X{requestId}]%n</pattern>
             </encoder>
-            <filter class="ch.qos.logback.classic.filter.LevelFilter">
-                <level>INFO</level>
-                <onMatch>ACCEPT</onMatch>
-                <onMismatch>DENY</onMismatch>
-            </filter>
-        </appender>
-
-        <appender name="ERROR_FILE_PROD" class="ch.qos.logback.core.rolling.RollingFileAppender">
-            <file>/logs/error.log</file>
-            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                <fileNamePattern>/logs/error.%d{yyyy-MM-dd}.log</fileNamePattern>
-                <maxHistory>30</maxHistory>
-            </rollingPolicy>
-            <encoder>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg [%X{requestId}]%n</pattern>
-            </encoder>
-            <filter class="ch.qos.logback.classic.filter.LevelFilter">
-                <level>ERROR</level>
-                <onMatch>ACCEPT</onMatch>
-                <onMismatch>DENY</onMismatch>
-            </filter>
-        </appender>
-
-        <appender name="WARN_FILE_PROD" class="ch.qos.logback.core.rolling.RollingFileAppender">
-            <file>/logs/warn.log</file>
-            <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-                <fileNamePattern>/logs/warn.%d{yyyy-MM-dd}.log</fileNamePattern>
-                <maxHistory>30</maxHistory>
-            </rollingPolicy>
-            <encoder>
-                <pattern>%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg [%X{requestId}]%n</pattern>
-            </encoder>
-            <filter class="ch.qos.logback.classic.filter.LevelFilter">
-                <level>WARN</level>
-                <onMatch>ACCEPT</onMatch>
-                <onMismatch>DENY</onMismatch>
-            </filter>
         </appender>
 
         <!-- 루트 로거 설정 -->
         <root level="INFO">
             <appender-ref ref="STDOUT" />
             <appender-ref ref="INFO_FILE_PROD" />
-            <appender-ref ref="ERROR_FILE_PROD" />
-            <appender-ref ref="WARN_FILE_PROD" />
         </root>
     </springProfile>
-
 </configuration>

--- a/Server/src/test/java/JGS/CasperEvent/domain/event/controller/eventController/RushEventControllerTest.java
+++ b/Server/src/test/java/JGS/CasperEvent/domain/event/controller/eventController/RushEventControllerTest.java
@@ -111,6 +111,7 @@ public class RushEventControllerTest {
         given(rushEventService.getRushEventRate(any())).willReturn(rushEventRateResponseDto);
 
         RushEventResultResponseDto rushEventResultResponseDto = new RushEventResultResponseDto(
+                1,
                 315L,
                 1000L,
                 1L,
@@ -245,6 +246,7 @@ public class RushEventControllerTest {
 
         // then
         perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.optionId").value(1))
                 .andExpect(jsonPath("$.leftOption").value(315))
                 .andExpect(jsonPath("$.rightOption").value(1000))
                 .andExpect(jsonPath("$.rank").value(1))

--- a/Server/src/test/java/JGS/CasperEvent/domain/event/service/eventService/RushEventServiceTest.java
+++ b/Server/src/test/java/JGS/CasperEvent/domain/event/service/eventService/RushEventServiceTest.java
@@ -224,6 +224,7 @@ class RushEventServiceTest {
  
         // then
         assertNotNull(result);
+        assertEquals(1, result.getOptionId());
         assertEquals(700, result.getLeftOption());
         assertEquals(500, result.getRightOption());
         assertEquals(700, result.getTotalParticipants());
@@ -258,6 +259,7 @@ class RushEventServiceTest {
 
         // then
         assertNotNull(result);
+        assertEquals(2, result.getOptionId());
         assertEquals(700, result.getLeftOption());
         assertEquals(500, result.getRightOption());
         assertEquals(500, result.getTotalParticipants());
@@ -292,6 +294,7 @@ class RushEventServiceTest {
 
         // then
         assertNotNull(result);
+        assertEquals(1, result.getOptionId());
         assertEquals(700, result.getLeftOption());
         assertEquals(500, result.getRightOption());
         assertEquals(700, result.getTotalParticipants());
@@ -325,6 +328,7 @@ class RushEventServiceTest {
 
         // then
         assertNotNull(result);
+        assertEquals(1, result.getOptionId());
         assertEquals(500, result.getLeftOption());
         assertEquals(500, result.getRightOption());
         assertEquals(1000, result.getTotalParticipants());
@@ -358,6 +362,7 @@ class RushEventServiceTest {
 
         // then
         assertNotNull(result);
+        assertEquals(1, result.getOptionId());
         assertEquals(500, result.getLeftOption());
         assertEquals(500, result.getRightOption());
         assertEquals(1000, result.getTotalParticipants());


### PR DESCRIPTION
## 🖥️ Preview

close #192 

## ✏️ 한 일
* 선착순 이벤트 결과 응답 DTO에 optionId 필드 추가
* DTO 변화에 맞게 테스트 코드 수정
* 로그가 각 레벨별로 최대 1GB만 쌓이도록 변경

## ❗️ 발생한 이슈 (해결 방안)

## ❓ 논의가 필요한 사항