### PR TITLE
기존 RequestInterceptor 에서 예외 로그를 처리 못 하던 에러 해결

### DIFF
--- a/Server/src/main/java/JGS/CasperEvent/domain/event/controller/eventController/LotteryEventController.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/controller/eventController/LotteryEventController.java
@@ -21,7 +21,6 @@ import org.springframework.web.bind.annotation.*;
 import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
-import java.nio.file.attribute.UserPrincipalNotFoundException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.util.List;
@@ -75,7 +74,7 @@ public class LotteryEventController {
             @ApiResponse(responseCode = "404", description = "User has not applied")
     })
     @GetMapping("/applied")
-    public ResponseEntity<LotteryParticipantResponseDto> GetLotteryParticipant(HttpServletRequest request) throws UserPrincipalNotFoundException {
+    public ResponseEntity<LotteryParticipantResponseDto> GetLotteryParticipant(HttpServletRequest request) {
         BaseUser user = (BaseUser) request.getAttribute("user");
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/LotteryEventService.java
+++ b/Server/src/main/java/JGS/CasperEvent/domain/event/service/eventService/LotteryEventService.java
@@ -24,7 +24,6 @@ import javax.crypto.BadPaddingException;
 import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.SecretKey;
-import java.nio.file.attribute.UserPrincipalNotFoundException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
@@ -64,9 +63,9 @@ public class LotteryEventService {
         return casperBotDto;
     }
 
-    public LotteryParticipantResponseDto getLotteryParticipant(BaseUser user) throws UserPrincipalNotFoundException {
+    public LotteryParticipantResponseDto getLotteryParticipant(BaseUser user) {
         LotteryParticipants participant = lotteryParticipantsRepository.findByBaseUser(user)
-                .orElseThrow(() -> new UserPrincipalNotFoundException("응모 내역이 없습니다."));
+                .orElseThrow(() -> new CustomException("응모 내역이 없습니다.", CustomErrorCode.USER_NOT_FOUND));
         return LotteryParticipantResponseDto.of(participant, getCasperBot(participant.getCasperId()));
     }
 

--- a/Server/src/main/java/JGS/CasperEvent/global/error/GlobalExceptionHandler.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/error/GlobalExceptionHandler.java
@@ -2,45 +2,31 @@ package JGS.CasperEvent.global.error;
 
 import JGS.CasperEvent.global.enums.CustomErrorCode;
 import JGS.CasperEvent.global.error.exception.CustomException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.springframework.web.bind.MissingRequestCookieException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
-import java.nio.file.attribute.UserPrincipalNotFoundException;
-
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler  {
 
     @ExceptionHandler(CustomException.class)
     public ResponseEntity<ErrorResponse> handler(CustomException e){
+        log.error("CustomException [{}]", e.getMessage(), e);
         return ResponseEntity
                 .status(HttpStatus.valueOf(e.getErrorCode().getStatus()))
                 .body(ErrorResponse.of(e.getErrorCode(), e.getMessage()));
     }
 
-    @ExceptionHandler(MissingRequestCookieException.class)
-    public ResponseEntity<ErrorResponse> missingCookieHandler(){
-        return ResponseEntity
-                .status(HttpStatus.UNAUTHORIZED)
-                .body(ErrorResponse.of(CustomErrorCode.UNAUTHORIZED));
-    }
-
-    @ExceptionHandler(UserPrincipalNotFoundException.class)
-    public ResponseEntity<ErrorResponse> userPrincipalNotFoundHandler(){
-        return ResponseEntity
-                .status(HttpStatus.CONFLICT)
-                .body(ErrorResponse.of(CustomErrorCode.USER_NOT_FOUND));
-    }
-
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> methodArgumentNotValidExceptionHandler(MethodArgumentNotValidException e){
-        BindingResult bindingResult = e.getBindingResult();
+        log.error("MethodArgumentNotValidException [{}]", e.getMessage(), e);
 
+        BindingResult bindingResult = e.getBindingResult();
         StringBuilder builder = new StringBuilder();
         for (FieldError fieldError : bindingResult.getFieldErrors()) {
             builder.append(fieldError.getDefaultMessage());
@@ -56,6 +42,7 @@ public class GlobalExceptionHandler  {
 
     @ExceptionHandler(RuntimeException.class)
     public ResponseEntity<ErrorResponse> RuntimeExceptionHandler(RuntimeException e){
+        log.error("RuntimeException [{}]", e.getMessage(), e);
         return ResponseEntity
                 .status(HttpStatus.BAD_REQUEST)
                 .body(ErrorResponse.of(CustomErrorCode.BAD_REQUEST, e.getMessage()));

--- a/Server/src/main/java/JGS/CasperEvent/global/interceptor/RequestInterceptor.java
+++ b/Server/src/main/java/JGS/CasperEvent/global/interceptor/RequestInterceptor.java
@@ -38,11 +38,6 @@ public class RequestInterceptor implements HandlerInterceptor {
 
     @Override
     public void afterCompletion(@NonNull HttpServletRequest request, @NonNull HttpServletResponse response, @NonNull Object handler, Exception ex) {
-        // 예외 발생 시 로그 추가
-        if (ex != null) {
-            log.error("Exception [{}]", ex.getMessage());
-        }
-
         log.info("Response {} [{}]", response.getStatus(), handler);
 
         // 요청이 완료된 후 MDC에서 requestId 제거

--- a/Server/src/test/java/JGS/CasperEvent/domain/event/service/eventService/LotteryEventServiceTest.java
+++ b/Server/src/test/java/JGS/CasperEvent/domain/event/service/eventService/LotteryEventServiceTest.java
@@ -27,7 +27,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import javax.crypto.*;
 import javax.crypto.spec.SecretKeySpec;
-import java.nio.file.attribute.UserPrincipalNotFoundException;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
@@ -128,7 +127,7 @@ class LotteryEventServiceTest {
 
     @Test
     @DisplayName("응모 내역 조회 테스트 - 성공")
-    void getLotteryParticipants_Success() throws UserPrincipalNotFoundException {
+    void getLotteryParticipants_Success() {
         //given
         given(lotteryParticipantsRepository.findByBaseUser(user))
                 .willReturn(Optional.ofNullable(lotteryParticipants));


### PR DESCRIPTION
## 🖥️ Preview

## ✏️ 한 일
* GlobalExceptionHandler 에서 error log 를 남기도록 수정.
* GlobalExceptionHandler 에 필요없는 Handler 제거.

## ❗️ 발생한 이슈 (해결 방안)
* 기존 RequestInterceptor 에서 예외를 잡아서 error log 를 남기도록 구현했는데, 이미 GlobalExceptionHandler 에서 예외를 처리하던 것이 원인이었음.

## ❓ 논의가 필요한 사항